### PR TITLE
Allow false attributes

### DIFF
--- a/lib/representable.rb
+++ b/lib/representable.rb
@@ -81,7 +81,8 @@ private
   
   # Parse value from doc and update the model property.
   def uncompile_fragment(bin, doc)
-    value = read_fragment_for(bin, doc) || bin.definition.default
+    value = read_fragment_for(bin, doc)
+    value = bin.definition.default if value.nil?
     send(bin.definition.setter, value)
   end
   

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -253,6 +253,11 @@ class RepresentableTest < MiniTest::Spec
     it "always returns self" do
       assert_equal @band, @band.update_properties_from({"name"=>"Nofx"}, {}, Representable::JSON)
     end
+
+    it "allows false attributes" do
+      @band.update_properties_from({"groupies"=>false}, {}, Representable::JSON)
+      assert_equal false, @band.groupies
+    end
   end
   
   describe "#create_representation_with" do


### PR DESCRIPTION
This change allows attributes to be false. Previously they were omitted like nil attributes are.
