### PR TITLE
add Representable::JSON::AutoCollection

### DIFF
--- a/lib/representable/json/auto_collection.rb
+++ b/lib/representable/json/auto_collection.rb
@@ -1,0 +1,20 @@
+module Representable::JSON
+  module AutoCollection
+    def self.included(base)
+      base.class_eval do
+        include Representable::JSON::Collection
+        extend ClassMethods
+      end
+    end
+
+    module ClassMethods
+      def items(options, &block)
+        options[:extend] = Module.new do
+          include Representable::JSON
+          instance_exec &block
+        end
+        collection :_self, options
+      end
+    end
+  end
+end

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -485,6 +485,30 @@ end
     end
   end
 
+  require 'representable/json/auto_collection'
+  class CollectionRepresenterTest < MiniTest::Spec
+    describe "JSON::AutoCollection" do
+      describe "with contained objects" do
+        before do
+          @songs_representer = Module.new do
+            include Representable::JSON::AutoCollection
+            items :class => Song do
+              include Representable::JSON
+              property :name
+            end
+          end
+        end
+
+        it "renders objects with #to_json" do
+          assert_json "[{\"name\":\"Days Go By\"},{\"name\":\"Can't Take Them All\"}]", [Song.new("Days Go By"), Song.new("Can't Take Them All")].extend(@songs_representer).to_json
+        end
+
+        it "returns objects array from #from_json" do
+          assert_equal [Song.new("Days Go By"), Song.new("Can't Take Them All")], [].extend(@songs_representer).from_json("[{\"name\":\"Days Go By\"},{\"name\":\"Can't Take Them All\"}]")
+        end
+      end
+    end
+  end
 
   require 'representable/json/hash'
   class HashRepresenterTest < MiniTest::Spec


### PR DESCRIPTION
this simplify the following:

``` ruby
module SongRepresenter
  include Representable::JSON

  property :title
end

module SongsRepresenter
  include Representable::JSON::Collection

  items :class => Song
end

[Song.new(:title => "Fallout"), Song.new(:title => "Synchronicity")].extend(SongsRepresenter).to_json
```

to this:

``` ruby
module SongsRepresenter
  include Representable::JSON::AutoCollection

  items :class => Song do
    property :title
  end
end

[Song.new(:title => "Fallout"), Song.new(:title => "Synchronicity")].extend(SongsRepresenter).to_json
```

The cases where you need a collection representer not DRY at the moment. Potentially, we can build it directly into Collection. The same should be follow as XML::Collection when #19 works
