### PR TITLE
add Representable::JSON#collection_wrapper

### DIFF
--- a/lib/representable/json.rb
+++ b/lib/representable/json.rb
@@ -21,6 +21,14 @@ module Representable
       def from_json(*args, &block)
         create_represented(*args, &block).from_json(*args)
       end
+
+      def collection_wrapper opions = {}
+        representer = self
+        Module.new do
+          include Representable::JSON::Collection
+          items({:extend => representer}.merge(opions))
+        end
+      end
     end
     
     

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -485,6 +485,26 @@ end
     end
   end
 
+  class CollectionRepresenterTest < MiniTest::Spec
+    describe "JSON#collection_wrapper" do
+      describe "with contained objects" do
+        before do
+          @song_representer = Module.new do
+            include Representable::JSON
+            property :name
+          end
+        end
+
+        it "renders objects with #to_json" do
+          assert_json "[{\"name\":\"Days Go By\"},{\"name\":\"Can't Take Them All\"}]", [Song.new("Days Go By"), Song.new("Can't Take Them All")].extend(@song_representer.collection_wrapper).to_json
+        end
+
+        it "returns objects array from #from_json" do
+          assert_equal [Song.new("Days Go By"), Song.new("Can't Take Them All")], [].extend(@song_representer.collection_wrapper(:class => Song)).from_json("[{\"name\":\"Days Go By\"},{\"name\":\"Can't Take Them All\"}]")
+        end
+      end
+    end
+  end
 
   require 'representable/json/hash'
   class HashRepresenterTest < MiniTest::Spec


### PR DESCRIPTION
this is a alternative way compare to #20 to make Collection Representers more DRY

this simplify the following:

``` ruby
module SongRepresenter
  include Representable::JSON

  property :title
end

module SongsRepresenter
  include Representable::JSON::Collection

  items :class => Song
end

[Song.new(:title => "Fallout"), Song.new(:title => "Synchronicity")].extend(SongsRepresenter).to_json
```

to this:

``` ruby
module SongRepresenter
  include Representable::JSON
  property :title
end

[Song.new(:title => "Fallout"), Song.new(:title => "Synchronicity")].extend(SongRepresenter.collection_wrapper(:class => Song)).to_json
```

Im not really sure what is the best method name is, #collection_wrapper or #collection_representer?

The same should be follow as XML::Collection when #19 works
