### PR TITLE
do not double initialized constant PunkRock

### DIFF
--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -388,7 +388,7 @@ class RepresentableTest < MiniTest::Spec
   describe "Config" do
     before do
       @config = Representable::Config.new
-      PunkRock = Class.new
+      PunkRock = Class.new unless defined? PunkRock
     end
     
     describe "wrapping" do


### PR DESCRIPTION
remove the `representable/test/representable_test.rb:391: warning: already initialized constant PunkRock` warning
