### PR TITLE
Remove_namespaces! for Nokogiri XML document parsing

### DIFF
--- a/lib/representable/xml.rb
+++ b/lib/representable/xml.rb
@@ -32,7 +32,7 @@ module Representable
     
     
     def from_xml(doc, *args)
-      node = Nokogiri::XML(doc).root
+      node = Nokogiri::XML(doc).remove_namespaces!.root
       from_node(node, *args)
     end
     

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -79,6 +79,18 @@ class XmlTest < MiniTest::Spec
         assert_equal ["Nofx", "NOFX"], [@band.name, @band.label]
       end
     end
+
+    describe "#from_xml with xmlns present" do
+      before do
+        @band = @Band.new
+        @xml = %{<band xmlns="exists"><name>Nofx</name><label>NOFX</label></band>}
+      end
+      
+      it "parses with xmlns present" do
+        @band.from_xml(@xml)
+        assert_equal ["Nofx", "NOFX"], [@band.name, @band.label]
+      end
+    end
     
     
     describe "#from_node" do


### PR DESCRIPTION
I've come upon a situation where incoming XML is namespaced, e.g.

``` xml
<songs xmlns="disasterous">
  <song title="Never Gonna Give You Up"/>
</songs>
```

Consuming such XML fails because accessing elements in representable doesn't take namespaced tags into account. I've found a quick and dirty solution, using (remove_namespaces!)[http://nokogiri.org/Nokogiri/XML/Document.html#method-i-remove_namespaces-21]. You can find the solution and the accompanying test in pull request.

That said, I am not really sure this is the best way to go. Maybe representable could use namespaced access, as explained (here)[http://stackoverflow.com/questions/1737572/why-doesnt-nokogiri-xpath-like-xmlns-declarations], but not sure how to apply it. Also, this (article)[http://tenderlovemaking.com/2009/04/23/namespaces-in-xml.html], referenced from Nokogiri docs, really gives some thought. 

But maybe none of this apply to consuming XML in representers. What do you think?
