### PR TITLE
Aliased :from to :as in accessor property

### DIFF
--- a/lib/representable/definition.rb
+++ b/lib/representable/definition.rb
@@ -36,7 +36,7 @@ module Representable
     end
     
     def from
-      (options[:from] || name).to_s
+      (options[:from] || options[:as] || name).to_s
     end
     
     def default_for(value)

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -285,6 +285,24 @@ module JsonTest
       end
     end
 
+    describe ":as => :songName" do
+      class Song
+        include Representable::JSON
+        property :name, :as => :songName
+        attr_accessor :name
+      end
+
+      it "respects :as in #from_json" do
+        song = Song.from_json({:songName => "Run To The Hills"}.to_json)
+        assert_equal "Run To The Hills", song.name
+      end
+
+      it "respects :as in #to_json" do
+        song = Song.new; song.name = "22 Acacia Avenue"
+        assert_json '{"songName":"22 Acacia Avenue"}', song.to_json
+      end
+    end
+
     describe ":default => :value" do
       before do
         @Album = Class.new do

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -170,6 +170,11 @@ class RepresentableTest < MiniTest::Spec
         band = Class.new(Band) { property :friends, :from => :friend }
         assert_equal "friend", band.representable_attrs.last.from
       end
+
+      it "can be set explicitly with as" do
+        band = Class.new(Band) { property :friends, :as => :friend }
+        assert_equal "friend", band.representable_attrs.last.from
+      end
       
       it "is infered from the name implicitly" do
         band = Class.new(Band) { property :friends }


### PR DESCRIPTION
When creating a document from an object the DSL language was confusing, so this change allows you to do both:

```
property :title, :from => :display_title
```

and:

```
property :title, :as => :display_title
```

It would read more like: Display the property 'title' in the document as
'display_title'"

Let me know if there are other cases you would like to add test coverage, or if there is a better way to implement the feature. I didn't really get too deep into the code since I found the easy way to get this done.
