### PR TITLE
Give option to set the name of a property

### DIFF
--- a/lib/representable/definition.rb
+++ b/lib/representable/definition.rb
@@ -40,7 +40,7 @@ module Representable
     end
     
     def from
-      (options[:from] || name).to_s
+      (options[:from] || @name).to_s
     end
     
     def default_for(value)

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -58,6 +58,20 @@ class DefinitionTest < MiniTest::Spec
     it "responds to #sought_type" do
       assert_equal nil, @def.sought_type
     end
+
+    describe '#from' do
+      it 'returns the :from value' do
+          assert_equal "tracks", Representable::Definition.new(:songs, :from => :tracks).from
+      end
+
+      it 'returns the original @name when :name is redifined' do
+          assert_equal "songs", Representable::Definition.new(:songs, :name => :tracks).from
+      end
+
+      it 'returns the :from value when :name is redifined' do
+          assert_equal "beats", Representable::Definition.new(:beats, :name => :tracks, :from => :beats).from
+      end
+    end
     
     describe "#clone" do
       it "clones @options" do

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -445,6 +445,26 @@ class RepresentableTest < MiniTest::Spec
       end
     end
 
+    describe "property with :name" do
+      before do
+        @band = Class.new(Band) {
+            attr_accessor :groupies
+        }.new
+        @band.groupies = 2
+      end
+      representer! do
+        property :fans, :name => :groupies
+      end
+
+      it "sets the key to the original name, and uses the new name as the getter" do
+        assert_equal({"fans" => 2}, @band.extend(representer).to_hash)
+      end
+      it "uses the new name and translates that into the original name" do
+        @band.extend(representer).from_hash({"fans"=> 4})
+        assert_equal(4, @band.groupies)
+      end
+    end
+
     describe "property with :extend" do
       representer! do
         property :name, :extend => lambda { |name| name.is_a?(UpcaseString) ? UpcaseRepresenter : DowncaseRepresenter }, :class => String


### PR DESCRIPTION
Sometimes it may be useful to have the ability to set the name (the name of the attribute of the object you are representing) in the options passed into a Definition. 

```
class Article
  include Representable::JSON
  attr_accessor :title
  property :heading, :name => :title # implicit :from => :heading
end
```

Now let's use it.

```
a = Article.new
a.title = "Godzilla!"
a.to_json
```

Yields 

```
{"heading" : "Godzilla!"}
```
