### PR TITLE
give option to supply a Proc to a Definition that acts on the object

### DIFF
--- a/lib/representable.rb
+++ b/lib/representable.rb
@@ -87,7 +87,7 @@ private
   
   # Retrieve value and write fragment to the doc.
   def compile_fragment(bin, doc)
-    value = send(bin.getter)
+    value = bin.proc ? bin.proc.call(self) : send(bin.getter)
     
     write_fragment(bin, doc, value)
   end

--- a/lib/representable/definition.rb
+++ b/lib/representable/definition.rb
@@ -63,5 +63,9 @@ module Representable
     def default
       options[:default]
     end
+
+    def proc
+      options[:proc]
+    end
   end
 end

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -181,6 +181,15 @@ class DefinitionTest < MiniTest::Spec
 
   end
 
+  describe '#proc' do
+    it 'returns nil if unset' do
+      assert_equal nil, Representable::Definition.new(:song).proc
+    end
+
+    it 'returns a proc if set' do
+      assert Representable::Definition.new(:song, :proc => Proc.new {|song| song}).proc
+    end
+  end
 
   describe ":collection => true" do
     before do

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -329,6 +329,24 @@ class RepresentableTest < MiniTest::Spec
       assert_equal({"name" => "Iron Maiden"}, hash)
     end
 
+    describe "the proc option" do
+      it "gets values from the object" do
+        @band = Class.new(Band) { property :quote, :proc => Proc.new {|band| band.name + " turns it up to 11"  }}.new
+        @band.name = "Spinal Tap"
+
+        hash = @band.send(:create_representation_with, {}, {}, Representable::Hash::PropertyBinding)
+        assert_equal({"quote" => "Spinal Tap turns it up to 11"}, hash)
+      end
+
+      it "overrides the name getter when used" do
+        @band = Class.new(Band) { property :name, :proc => Proc.new {|band| "Justin Beiber" }}.new
+        @band.name = "Spinal Tap"
+
+        hash = @band.send(:create_representation_with, {}, {}, Representable::Hash::PropertyBinding)
+        assert_equal({"name" => "Justin Beiber"}, hash)
+      end
+    end
+
     it "does not write nil attributes" do
       @band.groupies = nil
       assert_equal({"name"=>"No One's Choice"}, @band.send(:create_representation_with, {}, {}, Representable::Hash::PropertyBinding))


### PR DESCRIPTION
Give the option to supply a Proc to a Defintion that acts on the object
being represented.

```
class SensationalArticle
  include Representable::JSON
  attr_accessor :title

  property :title, :proc => Proc.new {|article| article.title + "!"}

  property :lede, :writable => false, :proc => Proc.new { |article|
        "Experts are warning that " + article.title.downcase + "!!"
  }
end
```

Now let's use it. 

```
a = SensationalArticle.new
a.title = "Bees Are Found To Make Honey"
a.to_json
```

Yields

```
{"title" : "Bees Are Found to make Honey!",
 "lede"  : "Experts are warning that bees are found to make honey!!"}
```
