### PR TITLE
Add an example of overriding Virtus class-level coercion

### DIFF
--- a/test/coercion_test.rb
+++ b/test/coercion_test.rb
@@ -32,6 +32,7 @@ class VirtusCoercionTest < MiniTest::Spec
         property :track,        :type => Integer
 
         def track=(track_number)
+          # Not very elegant, but this is just a quick demo
           track_number = attribute_set[:track].coerce(track_number)
           track_number = 1 if track_number < 0
           super(track_number)


### PR DESCRIPTION
This isn't a "real" pull request, I'm just attaching my changes to Representable issue #34. I'm not sure what the best way to describe this behaviour is.
