### PR TITLE
support custom bindings, fixes #37

### DIFF
--- a/lib/representable/bindings/hash_bindings.rb
+++ b/lib/representable/bindings/hash_bindings.rb
@@ -17,6 +17,7 @@ module Representable
     
     class PropertyBinding < Representable::Binding
       def self.build_for(definition, *args)  # TODO: remove default arg.
+        return definition.instantiate_binding(*args)     if definition.has_binding?
         return CollectionBinding.new(definition, *args)  if definition.array?
         return HashBinding.new(definition, *args)        if definition.hash?
         new(definition, *args)

--- a/lib/representable/bindings/xml_bindings.rb
+++ b/lib/representable/bindings/xml_bindings.rb
@@ -25,6 +25,7 @@ module Representable
     
     class PropertyBinding < Binding
       def self.build_for(definition, *args)
+        return definition.instantiate_binding(*args)         if definition.has_binding?
         return CollectionBinding.new(definition, *args)      if definition.array?
         return HashBinding.new(definition, *args)            if definition.hash? and not definition.options[:use_attributes] # FIXME: hate this.
         return AttributeHashBinding.new(definition, *args)   if definition.hash? and definition.options[:use_attributes]

--- a/lib/representable/bindings/yaml_bindings.rb
+++ b/lib/representable/bindings/yaml_bindings.rb
@@ -20,6 +20,7 @@ module Representable
 
     class PropertyBinding < Representable::Hash::PropertyBinding
       def self.build_for(definition, *args)
+        return definition.instantiate_binding(*args)    if definition.has_binding?
         return CollectionBinding.new(definition, *args) if definition.array?
         new(definition, *args)
       end

--- a/lib/representable/definition.rb
+++ b/lib/representable/definition.rb
@@ -63,5 +63,17 @@ module Representable
     def default
       options[:default]
     end
+
+    def binding
+      options[:binding]
+    end
+
+    def has_binding?
+      options.has_key?(:binding)
+    end
+
+    def instantiate_binding *args
+      binding.new(self, *args)
+    end
   end
 end

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -181,6 +181,23 @@ class DefinitionTest < MiniTest::Spec
 
   end
 
+  describe "#has_binding?" do
+    it "returns true when :binding is set" do
+      assert_equal true, Representable::Definition.new(:songs, :binding => Object).has_binding?
+    end
+
+    it "returns false when :binding is not set" do
+      assert_equal false, Representable::Definition.new(:songs).has_binding?
+    end
+  end
+
+  describe "#instantiate_binding" do
+    it "instantiates the specified binding" do
+      binding = mock
+      binding.expects(:new).with(kind_of(Representable::Definition),:passed_args).returns(:instantiated_binding).once
+      assert_equal :instantiated_binding, Representable::Definition.new(:songs, :binding => binding).instantiate_binding(:passed_args)
+    end
+  end
 
   describe ":collection => true" do
     before do
@@ -230,6 +247,16 @@ class DefinitionTest < MiniTest::Spec
     it "responds to #hash?" do
       assert @def.hash?
       assert ! Representable::Definition.new(:songs).hash?
+    end
+  end
+
+  describe ":binding => Object" do
+    subject do
+      Representable::Definition.new(:songs, :binding => Object)
+    end
+
+    it "responds to #binding" do
+      assert_equal subject.binding, Object
     end
   end
 end

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -142,6 +142,12 @@ module JsonTest
         it "returns CollectionBinding" do
           assert_kind_of Representable::Hash::CollectionBinding, Representable::Hash::PropertyBinding.build_for(Def.new(:band, :collection => true), nil)
         end
+
+        it "returns custom bindings" do
+          binding = mock
+          binding.expects(:new).with(anything,:args).returns(:instantiated_binding)
+          assert_equal :instantiated_binding, Representable::Hash::PropertyBinding.build_for(Def.new(:band, :binding => binding), :args)
+        end
       end
 
       describe "#representable_bindings_for" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,7 +9,7 @@ require 'test/unit'
 require 'minitest/spec'
 require 'minitest/autorun'
 require 'test_xml/mini_test'
-require 'mocha'
+require 'mocha/setup'
 
 class Album
   attr_accessor :songs, :best_song

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -141,6 +141,12 @@ class XmlTest < MiniTest::Spec
       it "returns HashBinding" do
         assert_kind_of XML::HashBinding, XML::PropertyBinding.build_for(Def.new(:band, :hash => :true), nil)
       end
+
+      it "returns custom bindings" do
+        binding = mock
+        binding.expects(:new).with(anything,:args).returns(:instantiated_binding)
+        assert_equal :instantiated_binding, XML::PropertyBinding.build_for(Def.new(:band, :binding => binding), :args)
+      end
     end
     
     


### PR DESCRIPTION
Initial pass to add custom binding, about to actually use it.

For accepting a proc, any suggestion on what context to eval in? Was going to default to using the current definition for the context.
