### PR TITLE
Allow the use of method names as symbols for use in conditionals

### DIFF
--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -6,55 +6,55 @@ class RepresentableTest < MiniTest::Spec
     property :name
     attr_accessor :name
   end
-  
+
   class PunkBand < Band
     property :street_cred
     attr_accessor :street_cred
   end
-  
+
   module BandRepresentation
     include Representable
-    
+
     property :name
   end
-  
+
   module PunkBandRepresentation
     include Representable
     include BandRepresentation
-    
+
     property :street_cred
   end
-  
-  
+
+
   describe "#representable_attrs" do
     it "responds to #representable_attrs" do
       assert_equal 1, Band.representable_attrs.size
       assert_equal "name", Band.representable_attrs.first.name
     end
-    
+
     describe "in module" do
       it "returns definitions" do
         assert_equal 1, BandRepresentation.representable_attrs.size
         assert_equal "name", BandRepresentation.representable_attrs.first.name
       end
-      
+
       it "inherits to including modules" do
         assert_equal 2,  PunkBandRepresentation.representable_attrs.size
         assert_equal "name", PunkBandRepresentation.representable_attrs.first.name
         assert_equal "street_cred", PunkBandRepresentation.representable_attrs.last.name
       end
-      
+
       it "inherits to including class" do
         band = Class.new do
           include Representable
           include PunkBandRepresentation
         end
-        
+
         assert_equal 2,  band.representable_attrs.size
         assert_equal "name", band.representable_attrs.first.name
         assert_equal "street_cred", band.representable_attrs.last.name
       end
-      
+
       it "allows including the concrete representer module later" do
         vd = class VD
           attr_accessor :name, :street_cred
@@ -65,7 +65,7 @@ class RepresentableTest < MiniTest::Spec
         vd.street_cred = 1
         assert_json "{\"name\":\"Vention Dention\",\"street_cred\":1}", vd.to_json
       end
-      
+
       #it "allows including the concrete representer module only" do
       #  require 'representable/json'
       #  module RockBandRepresentation
@@ -78,29 +78,29 @@ class RepresentableTest < MiniTest::Spec
       #  vd.name        = "Van Halen"
       #  assert_equal "{\"name\":\"Van Halen\"}", vd.to_json
       #end
-      
+
       it "doesn't share inherited properties between family members" do
         parent = Module.new do
           include Representable
           property :id
         end
-        
+
         child = Module.new do
           include Representable
           include parent
         end
-        
+
         assert parent.representable_attrs.first != child.representable_attrs.first, "definitions shouldn't be identical"
       end
-      
+
     end
   end
-  
-  
+
+
   describe "Representable" do
     describe "inheritance" do
       class CoverSong < OpenStruct
-      end 
+      end
       module SongRepresenter
         include Representable::Hash
         property :name
@@ -124,36 +124,36 @@ class RepresentableTest < MiniTest::Spec
         include Representable::XML
         include Representable::JSON
         include PunkBandRepresentation
-        
+
         self.representation_wrap = "band"
         attr_accessor :name, :street_cred
       end
-      
+
       band = Bodyjar.new
       band.name = "Bodyjar"
-      
+
       assert_json "{\"band\":{\"name\":\"Bodyjar\"}}", band.to_json
       assert_xml_equal "<band><name>Bodyjar</name></band>", band.to_xml
     end
-    
+
     it "allows extending with different representers subsequentially" do
       module SongXmlRepresenter
         include Representable::XML
         property :name, :from => "name", :attribute => true
       end
-      
+
       module SongJsonRepresenter
         include Representable::JSON
         property :name
       end
-      
+
       @song = Song.new("Days Go By")
       assert_xml_equal "<song name=\"Days Go By\"/>", @song.extend(SongXmlRepresenter).to_xml
       assert_json "{\"name\":\"Days Go By\"}", @song.extend(SongJsonRepresenter).to_json
     end
   end
-  
-  
+
+
   describe "#property" do
     describe ":from" do
       # TODO: do this with all options.
@@ -166,68 +166,68 @@ class RepresentableTest < MiniTest::Spec
         band = Class.new(Band) { property :friends, :as => :friend }
         assert_equal "friend", band.representable_attrs.last.from
       end
-      
+
       it "is infered from the name implicitly" do
         band = Class.new(Band) { property :friends }
         assert_equal "friends", band.representable_attrs.last.from
       end
     end
   end
-  
+
   describe "#collection" do
     class RockBand < Band
       collection :albums
     end
-    
+
     it "creates correct Definition" do
       assert_equal "albums", RockBand.representable_attrs.last.name
       assert RockBand.representable_attrs.last.array?
     end
   end
-  
+
   describe "#hash" do
     it "also responds to the original method" do
       assert_kind_of Integer, BandRepresentation.hash
     end
   end
-  
-  
+
+
   describe "#representation_wrap" do
     class HardcoreBand
       include Representable
     end
-  
+
     class SoftcoreBand < HardcoreBand
     end
-    
+
     before do
       @band = HardcoreBand.new
     end
-    
-    
+
+
     it "returns false per default" do
       assert_equal nil, SoftcoreBand.new.send(:representation_wrap)
     end
-    
+
     it "infers a printable class name if set to true" do
       HardcoreBand.representation_wrap = true
       assert_equal "hardcore_band", @band.send(:representation_wrap)
     end
-    
+
     it "can be set explicitely" do
       HardcoreBand.representation_wrap = "breach"
       assert_equal "breach", @band.send(:representation_wrap)
     end
   end
-  
-  
+
+
   describe "#definition_class" do
     it "returns Definition class" do
       assert_equal Representable::Definition, Band.send(:definition_class)
     end
   end
 
-  
+
   # DISCUSS: i don't like the JSON requirement here, what about some generic test module?
   class PopBand
     include Representable::JSON
@@ -240,19 +240,19 @@ class RepresentableTest < MiniTest::Spec
     before do
       @band = PopBand.new
     end
-    
+
     it "copies values from document to object" do
       @band.update_properties_from({"name"=>"No One's Choice", "groupies"=>2}, {}, Representable::Hash::PropertyBinding)
       assert_equal "No One's Choice", @band.name
       assert_equal 2, @band.groupies
     end
-    
+
     it "accepts :exclude option" do
       @band.update_properties_from({"name"=>"No One's Choice", "groupies"=>2}, {:exclude => [:groupies]}, Representable::Hash::PropertyBinding)
       assert_equal "No One's Choice", @band.name
       assert_equal nil, @band.groupies
     end
-    
+
     it "accepts :include option" do
       @band.update_properties_from({"name"=>"No One's Choice", "groupies"=>2}, {:include => [:groupies]}, Representable::Hash::PropertyBinding)
       assert_equal 2, @band.groupies
@@ -265,11 +265,11 @@ class RepresentableTest < MiniTest::Spec
       assert_equal "Iron Maiden", @band.name
       assert_equal nil, @band.founders
     end
-    
+
     it "always returns self" do
       assert_equal @band, @band.update_properties_from({"name"=>"Nofx"}, {}, Representable::Hash::PropertyBinding)
     end
-    
+
     it "includes false attributes" do
       @band.update_properties_from({"groupies"=>false}, {}, Representable::Hash::PropertyBinding)
       assert_equal false, @band.groupies
@@ -281,21 +281,21 @@ class RepresentableTest < MiniTest::Spec
       end
       @band.update_properties_from({}, {}, Representable::Hash::PropertyBinding)
     end
-    
+
     it "ignores (no-default) properties not present in the incoming document" do
-      { Representable::JSON => [{}, Representable::Hash::PropertyBinding], 
+      { Representable::JSON => [{}, Representable::Hash::PropertyBinding],
         Representable::XML  => [xml(%{<band/>}), Representable::XML::PropertyBinding]
       }.each do |format, config|
         nested_repr = Module.new do # this module is never applied.
           include format
           property :created_at
         end
-        
+
         repr = Module.new do
           include format
           property :name, :class => Object, :extend => nested_repr
         end
-        
+
         @band = Band.new.extend(repr)
         @band.update_properties_from(config.first, {}, config.last)
         assert_equal nil, @band.name, "Failed in #{format}"
@@ -335,23 +335,23 @@ class RepresentableTest < MiniTest::Spec
       end
     end
   end
-  
+
   describe "#create_representation_with" do
     before do
       @band = PopBand.new
       @band.name = "No One's Choice"
       @band.groupies = 2
     end
-    
+
     it "compiles document from properties in object" do
       assert_equal({"name"=>"No One's Choice", "groupies"=>2}, @band.send(:create_representation_with, {}, {}, Representable::Hash::PropertyBinding))
     end
-    
+
     it "accepts :exclude option" do
       hash = @band.send(:create_representation_with, {}, {:exclude => [:groupies]}, Representable::Hash::PropertyBinding)
       assert_equal({"name"=>"No One's Choice"}, hash)
     end
-    
+
     it "accepts :include option" do
       hash = @band.send(:create_representation_with, {}, {:include => [:groupies]}, Representable::Hash::PropertyBinding)
       assert_equal({"groupies"=>2}, hash)
@@ -375,7 +375,7 @@ class RepresentableTest < MiniTest::Spec
       @band.groupies = false
       assert_equal({"name"=>"No One's Choice","groupies"=>false}, @band.send(:create_representation_with, {}, {}, Representable::Hash::PropertyBinding))
     end
-    
+
     describe "when :render_nil is true" do
       it "includes nil attribute" do
         mod = Module.new do
@@ -383,20 +383,20 @@ class RepresentableTest < MiniTest::Spec
           property :name
           property :groupies, :render_nil => true
         end
-        
+
         @band.extend(mod) # FIXME: use clean object.
         @band.groupies = nil
         hash = @band.send(:create_representation_with, {}, {}, Representable::Hash::PropertyBinding)
         assert_equal({"name"=>"No One's Choice", "groupies" => nil}, hash)
       end
-      
+
       it "includes nil attribute without extending" do
         mod = Module.new do
           include Representable::JSON
           property :name
           property :groupies, :render_nil => true, :extend => BandRepresentation
         end
-        
+
         @band.extend(mod) # FIXME: use clean object.
         @band.groupies = nil
         hash = @band.send(:create_representation_with, {}, {}, Representable::Hash::PropertyBinding)
@@ -417,35 +417,43 @@ class RepresentableTest < MiniTest::Spec
         to_hash(:include => [:original]).must_equal({"original"=>{"title"=>"Roxanne (Don't Put On The Red Light)"}})
     end
   end
-  
+
   describe ":if" do
     before do
       @pop = Class.new(PopBand) { attr_accessor :fame }
     end
-    
+
     it "respects property when condition true" do
       @pop.class_eval { property :fame, :if => lambda { true } }
       band = @pop.new
       band.update_properties_from({"fame"=>"oh yes"}, {}, Representable::Hash::PropertyBinding)
       assert_equal "oh yes", band.fame
     end
-    
+
     it "ignores property when condition false" do
       @pop.class_eval { property :fame, :if => lambda { false } }
       band = @pop.new
       band.update_properties_from({"fame"=>"oh yes"}, {}, Representable::Hash::PropertyBinding)
       assert_equal nil, band.fame
     end
-    
+
     it "ignores property when :exclude'ed even when condition is true" do
       @pop.class_eval { property :fame, :if => lambda { true } }
       band = @pop.new
       band.update_properties_from({"fame"=>"oh yes"}, {:exclude => [:fame]}, Representable::Hash::PropertyBinding)
       assert_equal nil, band.fame
     end
-    
+
     it "executes block in instance context" do
       @pop.class_eval { property :fame, :if => lambda { groupies } }
+      band = @pop.new
+      band.groupies = true
+      band.update_properties_from({"fame"=>"oh yes"}, {}, Representable::Hash::PropertyBinding)
+      assert_equal "oh yes", band.fame
+    end
+
+    it "evaluates named method in instance context" do
+      @pop.class_eval { property :fame, :if => :groupies }
       band = @pop.new
       band.groupies = true
       band.update_properties_from({"fame"=>"oh yes"}, {}, Representable::Hash::PropertyBinding)
@@ -470,8 +478,8 @@ class RepresentableTest < MiniTest::Spec
 
   describe ":getter and :setter" do
     representer! do
-      property :name, 
-        :getter => lambda { |args| "#{args[:welcome]} #{name}" }, 
+      property :name,
+        :getter => lambda { |args| "#{args[:welcome]} #{name}" },
         :setter => lambda { |val, args| self.name = "#{args[:welcome]} #{val}" }
     end
 
@@ -491,12 +499,12 @@ class RepresentableTest < MiniTest::Spec
       def to_hash(*); upcase; end
       def from_hash(hsh, *args); self.class.new hsh.upcase; end   # DISCUSS: from_hash must return self.
     end
-    module DowncaseRepresenter 
+    module DowncaseRepresenter
       def to_hash(*); downcase; end
       def from_hash(hsh, *args); hsh.downcase; end
     end
     class UpcaseString < String; end
-    
+
 
     describe "lambda blocks" do
       representer! do
@@ -614,29 +622,29 @@ class RepresentableTest < MiniTest::Spec
         OpenStruct.new(:title => "Affliction").extend(representer).to_hash.must_equal({:title => "Affliction"})
       end
     end
-    
+
   end
-  
+
   describe "Config" do
     subject { Representable::Config.new }
     PunkRock = Class.new
-    
+
     describe "wrapping" do
       it "returns false per default" do
         assert_equal nil, subject.wrap_for("Punk")
       end
-      
+
       it "infers a printable class name if set to true" do
         subject.wrap = true
         assert_equal "punk_rock", subject.wrap_for(PunkRock)
       end
-      
+
       it "can be set explicitely" do
         subject.wrap = "Descendents"
         assert_equal "Descendents", subject.wrap_for(PunkRock)
       end
     end
-    
+
     describe "clone" do
       it "clones all definitions" do
         subject << Object.new


### PR DESCRIPTION
`property :fame, :if => :groupies` will behave the same as `lambda { groupies }`
