### PR TITLE
Replace json library with yajl

### DIFF
--- a/lib/representable/json.rb
+++ b/lib/representable/json.rb
@@ -1,5 +1,5 @@
 require 'representable/hash'
-require 'yajl/json_gem'
+require 'multi_json'
 
 module Representable
   # Brings #to_json and #from_json to your object.

--- a/representable.gemspec
+++ b/representable.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   
   s.add_dependency "nokogiri"
-  s.add_dependency "yajl-ruby"
+  s.add_dependency "multi_json"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "test_xml"
@@ -28,4 +28,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency "mocha", ">= 0.13.0"
   s.add_development_dependency "mongoid"
   s.add_development_dependency "virtus", "~> 0.5.0"
+  s.add_development_dependency "yajl-ruby"
 end


### PR DESCRIPTION
Yet Another Json Library is a replacement for standard JSON library,
which parses json faster and with less memory usage.

Tests run on my machine:

with json library:

> Finished tests in 0.077247s, 776.7292 tests/s, 789.6747 assertions/s.

with yajl library:

> Finished tests in 0.049741s, 1206.2484 tests/s, 1226.3525 assertions/s.
