### PR TITLE
Support inline representers on collections

### DIFF
--- a/lib/representable.rb
+++ b/lib/representable.rb
@@ -127,9 +127,9 @@ private
       #   collection :products
       #   collection :products, :from => :item
       #   collection :products, :class => Product
-      def collection(name, options={})
+      def collection(name, options={}, &block)
         options[:collection] = true
-        property(name, options)
+        property(name, options, &block)
       end
 
       def hash(name=nil, options={})


### PR DESCRIPTION
Inline representers do not work for collections in 1.6.0 or current master. [Minimal example](https://gist.github.com/rsutphin/6165202). This patch makes them work — verified with tests and with the minimal example.
