### PR TITLE
Ensure enclosing decorator properties don't show up in inline decorators

### DIFF
--- a/lib/representable/decorator.rb
+++ b/lib/representable/decorator.rb
@@ -8,7 +8,10 @@ module Representable
     end
 
     def self.inline_representer(base_module, &block) # DISCUSS: separate module?
-      Class.new(self) do
+      # "self" is the enclosing decorator class. self.superclass ensures that
+      # this inline decorator is based one the same class as the enclosing
+      # decorator.
+      Class.new(self.superclass) do
         include base_module
         instance_exec &block
       end

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -467,6 +467,10 @@ class RepresentableTest < MiniTest::Spec
         Class.new(Representable::Decorator) do
           include Representable::Hash
 
+          # This property is here to ensure that property definitions aren't
+          # inherited by the inline decorator.
+          property :title
+
           property :song, :class => Song do
             property :name
           end
@@ -475,12 +479,20 @@ class RepresentableTest < MiniTest::Spec
         end
       end
 
+      let(:generated_song_representer) do
+        representer.representable_attrs.find { |attr| attr.name == 'song' }.options[:extend]
+      end
+
       it { request.to_hash.must_equal({"song"=>{"name"=>"Alive"}}) }
       it { request.from_hash({"song"=>{"name"=>"You've Taken Everything"}}).song.name.must_equal "You've Taken Everything"}
 
       it "uses an inline decorator" do
         request.to_hash
         song.wont_be_kind_of Representable
+      end
+
+      it 'does not inherit properties from the enclosing class' do
+        generated_song_representer.representable_attrs.map(&:name).wont_include('title')
       end
     end
   end


### PR DESCRIPTION
In 1.6.0 and master, attempts to use inline decorators where the enclosing decorator has other properties will fail with an exception like the below. The immediate problem is that the inline decorator is attempting to bind properties from the enclosing decorator. (See the test in the patch for a concrete example.)

The problem is that the inline decorator is made to descend from the enclosing decorator due to a possible-surprising behavior of `self` in class methods in ruby. The patch fixes the problem by using the enclosing decorator's superclass as the superclass for the inline decorator.

```
NoMethodError: undefined method `title' for #<Song:0x007f986b9d2af0 @name="Alive", @track=nil>
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:77:in `block in get'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:93:in `represented_exec_for'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:76:in `get'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:36:in `block in compile_fragment'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:93:in `represented_exec_for'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:35:in `compile_fragment'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:67:in `compile_fragment'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:35:in `serialize_property'
    /Users/rsutphin/ruby/representable/lib/representable/feature/readable_writeable.rb:11:in `serialize_property'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:25:in `block in serialize'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:24:in `each'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:24:in `serialize'
    /Users/rsutphin/ruby/representable/lib/representable.rb:29:in `create_representation_with'
    /Users/rsutphin/ruby/representable/lib/representable/hash.rb:38:in `to_hash'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:139:in `serialize'
    /Users/rsutphin/ruby/representable/lib/representable/bindings/hash_bindings.rb:42:in `serialize_for'
    /Users/rsutphin/ruby/representable/lib/representable/bindings/hash_bindings.rb:38:in `write'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:57:in `write_fragment_for'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:52:in `write_fragment'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:36:in `block in compile_fragment'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:93:in `represented_exec_for'
    /Users/rsutphin/ruby/representable/lib/representable/binding.rb:35:in `compile_fragment'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:67:in `compile_fragment'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:35:in `serialize_property'
    /Users/rsutphin/ruby/representable/lib/representable/feature/readable_writeable.rb:11:in `serialize_property'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:25:in `block in serialize'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:24:in `each'
    /Users/rsutphin/ruby/representable/lib/representable/mapper.rb:24:in `serialize'
    /Users/rsutphin/ruby/representable/lib/representable.rb:29:in `create_representation_with'
    /Users/rsutphin/ruby/representable/lib/representable/hash.rb:38:in `to_hash'
```
