### PR TITLE
Prevent Nokogiri::XML segfault by keeping XML Document around

### DIFF
--- a/lib/representable/xml.rb
+++ b/lib/representable/xml.rb
@@ -51,9 +51,10 @@ module Representable
 
     # Returns a Nokogiri::XML object representing this object.
     def to_node(options={})
+      options[:doc] ||= Nokogiri::XML::Document.new
       root_tag = options[:wrap] || representation_wrap
 
-      create_representation_with(Nokogiri::XML::Node.new(root_tag.to_s, Nokogiri::XML::Document.new), options, PropertyBinding)
+      create_representation_with(Nokogiri::XML::Node.new(root_tag.to_s, options[:doc]), options, PropertyBinding)
     end
 
     def to_xml(*args)


### PR DESCRIPTION
Fixes issue #65
