### PR TITLE
modified deserializer to create new objects as needed when :sync'ing

### DIFF
--- a/lib/representable/deserializer.rb
+++ b/lib/representable/deserializer.rb
@@ -32,12 +32,9 @@ module Representable
       # TODO: this used to be handled in #serialize where Object added it's behaviour. treat scalars as objects to remove this switch:
       return fragment unless @binding.typed?
 
-      if @binding.sync?
-        # TODO: this is also done when instance: { nil }
-        @object = @object.call # call Binding#get or Binding#get[i]
-      else
-        @object = @binding.create_object(fragment)
-      end
+      # If syncing, get the existing object (Binding#get or Binding#get[i]),
+      # If not syncing (or if the existing object is nil) create a new object.
+      @object = (@object.call if @binding.sync?) || @binding.create_object(fragment)
 
       # DISCUSS: what parts should be in this class, what in Binding?
       representable = prepare(@object)


### PR DESCRIPTION
When `:parse_strategy` is set to `:sync`, Representable assumes that the object exists.  This is often true.  But sometimes it can be that a developer (i.e. me :-) is dealing with an object that starts off `null` but that he'd like to later `:sync` once it is created.  When an object does not exist and the `:sync` strategy is used, things blow up with `NilClass` errors.

Nick et al have already pointed this out in the code:(https://github.com/apotonick/representable/blob/master/lib/representable/deserializer.rb#L36)

I _think_ the solution may be easy, and since I needed it to move forward I made a fork and am giving it a go.  Putting it here as a pull request in case Nick thinks this is in fact the solution.  If I'm missing something, feel free to say so and ignore.  I don't have much experience with the collection deserialization, so maybe there's something there I'm not considering.

See my posts on the roar-talk google group for reference: http://goo.gl/O25Vmh
