### PR TITLE
Add option to ignore property if instance is nil.

### DIFF
--- a/lib/representable/deserializer.rb
+++ b/lib/representable/deserializer.rb
@@ -39,6 +39,8 @@ module Representable
         @object = @binding.create_object(fragment)
       end
 
+      return if @binding.options[:ignore_nil_instance] && @object == fragment
+
       # DISCUSS: what parts should be in this class, what in Binding?
       representable = prepare(@object)
       deserialize(representable, fragment, @binding.user_options)

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -618,6 +618,17 @@ class RepresentableTest < MiniTest::Spec
         song.name.must_equal obj
         song.name.must_be_kind_of mod
       end
+
+      describe "with :ignore_nil_instance set and the instance being nil" do
+        representer! do
+          property :name, :extend => mod, :instance => lambda { |*| nil }, :ignore_nil_instance => true
+        end
+
+        it "does not evaluate the property" do
+          song = Song.new.extend(representer).from_hash("name" => "Eric's Had A Bad Day")
+          song.name.must_be_nil
+        end
+      end
     end
 
     describe "property with :extend" do


### PR DESCRIPTION
This is helpful when the property is a nested one and the associated representer expects a real instance, not a fragment.

We have a scenario where we use the 'instance' option with a Proc that might return nil based on the original data being deserialized. In this case, we would like Representable to ignore the property, and not pass down the fragment to the associated representer.

```
property :foo, extend: FooRepresenter, instance: lambda { |*| nil }, ignore_nil_instance: true
```

With that property, we don't want FooRepresenter to call its setters with a fragment (we use XML and receive a Nokogiri::Node). The instance Proc already reviewed the fragment and decided that nothing had to be done.

We are happy to hear thoughts or suggestions.

Cheers!
