### PR TITLE
Adding attributes to wrapped element in XML collection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ Gemfile.lock
 *.swp
 *.swo
 bin
+.idea

--- a/lib/representable/bindings/xml_bindings.rb
+++ b/lib/representable/bindings/xml_bindings.rb
@@ -23,6 +23,9 @@ module Representable
         end
 
         wrap_node << serialize_for(value, parent)
+        add_wrap_attributes_to(wrap_node)
+
+        wrap_node
       end
 
       def read(node)
@@ -79,6 +82,10 @@ module Representable
         return node if typed?
 
         node.content
+      end
+
+      def add_wrap_attributes_to(node)
+        self[:wrap_attributes].each { |name, value| node[name] = value } if self[:wrap_attributes]
       end
     end
 

--- a/test/xml_bindings_test.rb
+++ b/test/xml_bindings_test.rb
@@ -1,5 +1,5 @@
 require 'test_helper'
-require 'representable/json'  # FIXME.
+require 'representable/json' # FIXME.
 require 'representable/xml/collection'
 require 'representable/xml/hash'
 
@@ -105,6 +105,22 @@ class XMLBindingTest < MiniTest::Spec
         assert_equal "name", @doc.children.first.children.first.name
       end
     end
+
+    describe "with objects with wrapped element attributes" do
+      before do
+        @property = Representable::XML::PropertyBinding.new(Representable::Definition.new(:song, :collection => true, :class => SongWithRepresenter, :wrap => :doc, :wrap_attributes => {:foo => :bar}), nil, nil)
+      end
+
+      it "inserts with #write" do
+        @property.write(@doc, @song)
+        assert_xml_equal("<doc foo=\"bar\"><song><name>Thinning the Herd</name></song></doc>", @doc.to_s)
+        assert_kind_of Nokogiri::XML::Node, @doc.children.first
+        assert_equal "doc", @doc.children.first.name
+        assert_equal "bar", @doc.children.first["foo"]
+        assert_equal "song", @doc.children.first.children.first.name
+        assert_equal "name", @doc.children.first.children.first.children.first.name
+      end
+    end
   end
 
 
@@ -115,12 +131,12 @@ class XMLBindingTest < MiniTest::Spec
       end
 
       it "extracts with #read" do
-        assert_equal({"first" => "The Gargoyle", "second" => "Bronx"} , @property.read(Nokogiri::XML("<songs><first>The Gargoyle</first><second>Bronx</second></songs>")))
+        assert_equal({ "first" => "The Gargoyle", "second" => "Bronx" }, @property.read(Nokogiri::XML("<songs><first>The Gargoyle</first><second>Bronx</second></songs>")))
       end
 
       it "inserts with #write" do
         parent = Nokogiri::XML::Node.new("parent", @doc)
-        @property.write(parent, {"first" => "The Gargoyle", "second" => "Bronx"})
+        @property.write(parent, { "first" => "The Gargoyle", "second" => "Bronx" })
         assert_xml_equal("<songs><first>The Gargoyle</first><second>Bronx</second></songs>", parent.to_s)
       end
     end


### PR DESCRIPTION
We currently need to be able to add attributes to the element wrapping collections in XML, and from the code and the documentation I couldn't find an elegant way of doing this.

This will allow you to do the following:

``` ruby
collection :songs, :as => :song, :wrap => :songs, :wrap_attributes => {:foo => :bar}
```

which would generate the XML:

``` xml
<?xml version="1.0"?>
<songs foo="bar">
  <song>
    <name>Thinning the Herd</name>
  </song>
</songs>
```
