### PR TITLE
conditionally load appropriate Virtus module for coercion

### DIFF
--- a/lib/representable/coercion.rb
+++ b/lib/representable/coercion.rb
@@ -2,7 +2,8 @@ require "virtus"
 
 module Representable::Coercion
   class Coercer
-    include Virtus
+    virtus_coercer = Virtus.respond_to?(:model) ? Virtus.model : Virtus
+    include virtus_coercer
 
     def coerce(name, v) # TODO: test me.
       # set and get the value as i don't know where exactly coercion happens in virtus.


### PR DESCRIPTION
This addresses issue #61.  All tests pass using the current Virtus dependency (~> 0.5.0) as well as 1.0.x without the deprecation warning.
