### PR TITLE
Include 'representable/hash' to fix a breaking change from a recent patch-level upgrade

### DIFF
--- a/lib/representable/json.rb
+++ b/lib/representable/json.rb
@@ -1,4 +1,5 @@
 require 'multi_json'
+require 'representable/hash'
 
 module Representable
   # Brings #to_json and #from_json to your object.


### PR DESCRIPTION
Without including the base "representable" representable/json will error out.

```
versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/representable-1.8.3/lib/representable/json.rb:6:in
`<module:JSON>': uninitialized constant Hash::ClassMethods (NameError)
```

In the test_helper the `representable` lib is being included, so the error doesn't surface; however, if you follow the README and require only `representable/json` then it fails.

This patch will include the hash module and correct it.
