### PR TITLE
some makeup for the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,7 +317,7 @@ module SongRepresenter
 end
 ```
 
-You can now parse collections to `Song`s.
+You can now parse collections to `Song` instances.
 
 ```ruby
 [].extend(SongRepresenter.for_collection).from_hash([{title: "Sevens"}, {title: "Eric"}])


### PR DESCRIPTION
Change one sentences of the readme in [Representing Singular Models And Collections](https://github.com/apotonick/representable/blob/master/README.md#representing-singular-models-and-collections)

From:
You can now parse collections to `Song`s.

To:
You can now parse collections to `Song` instances.

I think the '`Song`s' looks bad and like a misspelling.
