### PR TITLE
Require 'representable/hash' from 'representable/yaml'.

### DIFF
--- a/lib/representable/yaml.rb
+++ b/lib/representable/yaml.rb
@@ -1,3 +1,4 @@
+require 'representable/hash'
 require 'representable/yaml/binding'
 
 module Representable


### PR DESCRIPTION
Fixes #122.
