### PR TITLE
Fix populator bug causing new data to never be set.

### DIFF
--- a/lib/representable.rb
+++ b/lib/representable.rb
@@ -87,10 +87,10 @@ private
     child_options[:wrap] = binding[:wrap] unless binding[:wrap].nil?
 
     # nested params:
-    if options[binding.name.to_sym]
-      child_options.merge!(options[binding.name.to_sym]) 
-      if options[binding.name.to_sym].key?("user_options")
-        child_options[:user_options].merge!(options[binding.name.to_sym]["user_options"])
+    if nested_options = options[binding.name.to_sym] || options[binding.name.to_s]
+      child_options.merge!(nested_options)
+      if nested_options.key?("user_options")
+        child_options[:user_options].merge!(nested_options["user_options"])
       end
     end
     child_options

--- a/lib/representable.rb
+++ b/lib/representable.rb
@@ -89,7 +89,9 @@ private
     # nested params:
     if options[binding.name.to_sym]
       child_options.merge!(options[binding.name.to_sym]) 
-      child_options[:user_options].merge!(options[binding.name.to_sym].symbolize_keys[:user_options])
+      if options[binding.name.to_sym].key?("user_options")
+        child_options[:user_options].merge!(options[binding.name.to_sym]["user_options"])
+      end
     end
     child_options
   end

--- a/lib/representable.rb
+++ b/lib/representable.rb
@@ -87,7 +87,10 @@ private
     child_options[:wrap] = binding[:wrap] unless binding[:wrap].nil?
 
     # nested params:
-    child_options.merge!(options[binding.name.to_sym]) if options[binding.name.to_sym]
+    if options[binding.name.to_sym]
+      child_options.merge!(options[binding.name.to_sym]) 
+      child_options[:user_options].merge!(options[binding.name.to_sym].symbolize_keys[:user_options])
+    end
     child_options
   end
 

--- a/lib/representable/populator.rb
+++ b/lib/representable/populator.rb
@@ -23,7 +23,6 @@ module Representable
 
       options[:parse_pipeline] = ->(input, options) do
         pipeline = Pipeline[*parse_functions] # TODO: AssignFragment
-        pipeline = Pipeline::Insert.(pipeline, SetValue, delete: true) # remove the setter function.
         pipeline = Pipeline::Insert.(pipeline, populator, replace: CreateObject::Populator) # let the actual populator do the job.
         # puts pipeline.extend(Representable::Pipeline::Debug).inspect
         pipeline

--- a/lib/representable/populator.rb
+++ b/lib/representable/populator.rb
@@ -5,14 +5,6 @@ module Representable
 
       object_class = binding[:class].(input, options)
       object       = object_class.find_by(id: input["id"]) || object_class.new
-      if options[:binding].array?
-        # represented.songs[i] = model
-        options[:represented].send(binding.getter)[options[:index]] = object
-      else
-        # represented.song = model
-        options[:represented].send(binding.setter, object)
-      end
-
       object
      }
 

--- a/representable.gemspec
+++ b/representable.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test_xml", "0.1.6"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "mongoid"
+  spec.add_development_dependency "mongoid", "~> 5.1.4"
   spec.add_development_dependency "virtus"
   spec.add_development_dependency "json", '>= 1.7.7'
 


### PR DESCRIPTION
Currently, the populator is coded to remove the `SetValue` operation from the pipeline, and in my testing this means that the populator runs and returns the correct record (e.g. via the "find or instantiate" logic), but then new values from the  are never set on that record.

In my testing, simply dropping this line makes everything work as expected.

I do see that `Representable::FindOrInstantiate` is coded to set it's result `object` on the represented object directly, so maybe I'm misunderstanding something about how populators are supposed to work? As currently coded, how are the `input` values ever going to be set on the populated `object`?
