### PR TITLE
Switch Coercion from Virtus to dry-types

### DIFF
--- a/lib/representable/coercion.rb
+++ b/lib/representable/coercion.rb
@@ -1,7 +1,11 @@
-require "virtus"
+require 'dry-types'
 
 module Representable
   module Coercion
+    module Types
+      include Dry::Types.module
+    end
+
     class Coercer
       def initialize(type)
         @type = type
@@ -9,8 +13,8 @@ module Representable
 
       # This gets called when the :render_filter or :parse_filter option is evaluated.
       # Usually the Coercer instance is an element in a Pipeline to allow >1 filters per property.
-      def call(input, options)
-        Virtus::Attribute.build(@type).coerce(input)
+      def call(input, _options)
+        @type.call(input)
       end
     end
 

--- a/representable.gemspec
+++ b/representable.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test_xml", "0.1.6"
   spec.add_development_dependency "minitest"
-  spec.add_development_dependency "virtus"
+  spec.add_development_dependency "dry-types", '~> 0.9'
   spec.add_development_dependency "ruby-prof"
   spec.add_development_dependency "multi_json"
 end

--- a/test/coercion_test.rb
+++ b/test/coercion_test.rb
@@ -1,19 +1,20 @@
 require 'test_helper'
 require 'representable/coercion'
 
-class VirtusCoercionTest < MiniTest::Spec
-  representer! do
+class CoercionTest < MiniTest::Spec
+  class SongRepresenter < Representable::Decorator
+    include Representable::Hash
     include Representable::Coercion
 
     property :title # no coercion.
-    property :length, :type => Float
+    property :length, :type => Types::Coercible::Float
 
     property :band, :class => OpenStruct do
-      property :founded, :type => Integer
+      property :founded, :type => Types::Coercible::Int
     end
 
     collection :songs, :class => OpenStruct do
-      property :ok, :type => Virtus::Attribute::Boolean
+      property :ok, :type => Types::Form::Bool
     end
   end
 
@@ -21,12 +22,11 @@ class VirtusCoercionTest < MiniTest::Spec
     :band  => OpenStruct.new(:founded => "1977"),
     :songs => [OpenStruct.new(:ok => 1), OpenStruct.new(:ok => 0)]) }
 
-  it { album.extend(representer).to_hash.must_equal({"title"=>"Dire Straits", "length"=>41.34, "band"=>{"founded"=>1977}, "songs"=>[{"ok"=>true}, {"ok"=>false}]}) }
+  it { SongRepresenter.new(album).to_hash.must_equal({"title"=>"Dire Straits", "length"=>41.34, "band"=>{"founded"=>1977}, "songs"=>[{"ok"=>true}, {"ok"=>false}]}) }
 
   it {
     album = OpenStruct.new
-    album.extend(representer)
-    album.from_hash({"title"=>"Dire Straits", "length"=>"41.34", "band"=>{"founded"=>"1977"}, "songs"=>[{"ok"=>1}, {"ok"=>0}]})
+    album = SongRepresenter.new(album).from_hash({"title"=>"Dire Straits", "length"=>"41.34", "band"=>{"founded"=>"1977"}, "songs"=>[{"ok"=>1}, {"ok"=>0}]})
 
     # it
     album.length.must_equal 41.34
@@ -39,7 +39,7 @@ class VirtusCoercionTest < MiniTest::Spec
     representer! do
       include Representable::Coercion
 
-      property :length, :type => Float,
+      property :length, :type => Representable::Coercion::Types::Coercible::Float,
       :parse_filter  => lambda { |input, options| "#{input}.1" }, # happens BEFORE coercer.
       :render_filter => lambda { |fragment,*| "#{fragment}.1" }
     end


### PR DESCRIPTION
**Rationale**

* Virtus is considered deprecated by its creator: https://www.reddit.com/r/ruby/comments/3sjb24/virtus_to_be_abandoned_by_its_creator/
* Mirrors a similar change in Disposable 0.3.0: https://github.com/apotonick/disposable/commit/baec36a08564f114a1326ed7f7e4437c561f4828

Issues to discuss w/ @apotonick:
* does this constitute a change to *our* API? - i.e. should this change be done wait until a minor/major release?
* if so, should we offer a DRY as an alternative coercion "engine"? (adds maintenance overhead though)
