### PR TITLE
Fix flickering JsonTest: require 'json'

### DIFF
--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -1,4 +1,5 @@
 require 'test_helper'
+require 'json'
 
 module JsonTest
 class JSONPublicMethodsTest < Minitest::Spec


### PR DESCRIPTION
Test is currently non-deterministic, passing or failing depending
on execution order: `Hash#to_json` is only defined once specific JSON
implementations (e.g. `json`) have been required. MultiJson requires
'json'/other implementations lazily.
