### PR TITLE
Fix 1.9.3 tests: force Nokogiri to resolve 1.6.x

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem "nokogiri", require: false
+  gem 'nokogiri', '~> 1.6.8', require: false
   gem "multi_json", require: false
   gem "minitest-line"
 end


### PR DESCRIPTION
Works around Bundler resolving a newer version of Nokogiri that is only supported on 2.2+ (possibly related to this issue: https://github.com/bundler/bundler-features/issues/95)

See downstream commits:

- https://github.com/trailblazer/roar/commit/b4c2cbf658e24ad0962e2fd348925492fe4beee9
- https://github.com/apotonick/roar-rails/commit/763196702658f9faa83226d8e3e01b6fa4a4a19f

Closes #208