### PR TITLE
Avoid warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: ruby
 cache: bundler
 sudo: false
 rvm:
-  - 1.9.3-p551
   - 2.0.0-p648
   - 2.1.9
   - 2.2.6
@@ -11,4 +10,11 @@ rvm:
 matrix:
   include:
   - rvm: jruby-9.1.5.0
-    env: JRUBY_OPTS="--profile.api"
+    env: JRUBY_OPTS="--profile.api"  # This enables profiling at JRuby
+    before_install: "gem install bundler"    # This ensures correct
+    before_script: "bundle update nokogiri"  # nokogiri version resolution
+  - rvm: 1.9.3-p551
+    before_install: "gem install bundler"    # This ensures correct
+    before_script: "bundle update nokogiri"  # nokogiri version resolution
+  allow_failures:
+    - rvm: jruby-9.1.5.0

--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,3 @@
 source 'https://rubygems.org'
 
 gemspec
-
-group :test do
-  gem 'nokogiri', '~> 1.6.8', require: false
-  gem "multi_json", require: false
-  gem "minitest-line"
-end
-
-# gem "declarative", path: "../declarative"
-# gem "declarative", github: "apotonick/declarative"
-
-# gem "uber","0.0.15" #, path: "../uber"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Representable maps Ruby objects to documents and back.
 [![Gitter Chat](https://badges.gitter.im/trailblazer/chat.svg)](https://gitter.im/trailblazer/chat)
 [![TRB Newsletter](https://img.shields.io/badge/TRB-newsletter-lightgrey.svg)](http://trailblazer.to/newsletter/)
 [![Build
-Status](https://travis-ci.org/apotonick/representable.svg)](https://travis-ci.org/apotonick/representable)
+Status](https://travis-ci.org/trailblazer/representable.svg)](https://travis-ci.org/trailblazer/representable)
 [![Gem Version](https://badge.fury.io/rb/representable.svg)](http://badge.fury.io/rb/representable)
 
 In other words: Take an object and decorate it with a representer module. This will allow you to render a JSON, XML or YAML document from that object. But that's only half of it! You can also use representers to parse a document and create or populate an object.

--- a/lib/representable/debug.rb
+++ b/lib/representable/debug.rb
@@ -1,16 +1,20 @@
+require 'representable/logger'
+
 module Representable
   module Debug
+    include Representable::Logger # provides #log
+
     def update_properties_from(doc, options, format)
-      puts
-      puts "[Deserialize]........."
-      puts "[Deserialize] document #{doc.inspect}"
+      log
+      log "[Deserialize]........."
+      log "[Deserialize] document #{doc.inspect}"
       super
     end
 
     def create_representation_with(doc, options, format)
-      puts
-      puts "[Serialize]........."
-      puts "[Serialize]"
+      log
+      log "[Serialize]........."
+      log "[Serialize]"
       super
     end
 
@@ -21,14 +25,16 @@ module Representable
     end
 
     module Binding
+      include Representable::Logger
+
       def evaluate_option(name, *args, &block)
-        puts "=====#{self[name]}" if name ==:prepare
-        puts (evaled = self[name]) ?
+        log "=====#{self[name]}" if name ==:prepare
+        log (evaled = self[name]) ?
           "                #evaluate_option [#{name}]: eval!!!" :
           "                #evaluate_option [#{name}]: skipping"
         value = super
-        puts "                #evaluate_option [#{name}]: --> #{value}" if evaled
-        puts "                #evaluate_option [#{name}]: -->= #{args.first}" if name == :setter
+        log "                #evaluate_option [#{name}]: --> #{value}" if evaled
+        log "                #evaluate_option [#{name}]: -->= #{args.first}" if name == :setter
         value
       end
 
@@ -44,18 +50,20 @@ module Representable
 
 
   module Pipeline::Debug
+    include Representable::Logger
+
     def call(input, options)
-      puts "Pipeline#call: #{inspect}"
-      puts "               input: #{input.inspect}"
+      log "Pipeline#call: #{inspect}"
+      log "               input: #{input.inspect}"
       super
     end
 
     def evaluate(block, memo, options)
       block.extend(Pipeline::Debug) if block.is_a?(Collect)
 
-      puts "  Pipeline   :   -> #{_inspect_function(block)} "
+      log "  Pipeline   :   -> #{_inspect_function(block)} "
       super.tap do |res|
-        puts "  Pipeline   :     result: #{res.inspect}"
+        log "  Pipeline   :     result: #{res.inspect}"
       end
     end
 

--- a/lib/representable/declarative.rb
+++ b/lib/representable/declarative.rb
@@ -47,8 +47,8 @@ module Representable
     NestedBuilder = ->(options) do
       Module.new do
         include Representable # FIXME: do we really need this?
-        feature *options[:_features]
-        include *options[:_base] # base when :inherit, or in decorator.
+        feature(*options[:_features])
+        include(*options[:_base]) # base when :inherit, or in decorator.
 
         module_eval &options[:_block]
       end

--- a/lib/representable/declarative.rb
+++ b/lib/representable/declarative.rb
@@ -50,7 +50,7 @@ module Representable
         feature(*options[:_features])
         include(*options[:_base]) # base when :inherit, or in decorator.
 
-        module_eval &options[:_block]
+        module_eval(&options[:_block])
       end
     end
 

--- a/lib/representable/deserializer.rb
+++ b/lib/representable/deserializer.rb
@@ -96,7 +96,7 @@ module Representable
   If = ->(input, options) { options[:binding].evaluate_option(:if, nil, options) ? input : Pipeline::Stop }
 
   StopOnExcluded = ->(input, options) do
-    return input unless private = options[:options]
+    return input unless options[:options]
     return input unless props = (options[:options][:exclude] || options[:options][:include])
 
     res = props.include?(options[:binding].name.to_sym) # false with include: Stop. false with exclude: go!

--- a/lib/representable/hash_methods.rb
+++ b/lib/representable/hash_methods.rb
@@ -21,7 +21,15 @@ module Representable
       excluding = options[:exclude]
       # TODO: use same filtering method as in normal representer in Representable#create_representation_with.
       return hash unless props = options.delete(:exclude) || options.delete(:include)
-      hash.reject { |k,v| excluding ? props.include?(k.to_sym) : !props.include?(k.to_sym) }
+
+      # Converting to Array and back to Hash
+      # just to avoid a `warning: extra states are no longer copied:`
+      # See: https://bugs.ruby-lang.org/issues/9275
+      ary = hash.to_a.reject do |k,v|
+        excluding ? props.include?(k.to_sym) : !props.include?(k.to_sym)
+      end
+
+      ::Hash[ary]
     end
   end
 end

--- a/lib/representable/logger.rb
+++ b/lib/representable/logger.rb
@@ -1,0 +1,88 @@
+# Provides really basic logging functionality.
+# You should include it on your class.
+#
+#     class MyClass
+#       include Representable::Logger
+#
+#       def my_method
+#         log "something"
+#       end
+#     end
+#
+# Or you can use the class methods.
+#
+#   logger = Representable::Logger
+#   logger.log("something")
+#
+# You can turn logging on or off with:
+#   Representable::Logger.on!
+#   Representable::Logger.off!
+#
+# And check for the current logging state with:
+#   Representable::Logger.on?
+#   Representable::Logger.off?
+#
+# The default logging state is *on!*.
+#
+# At tests, we have disabled logging to not polute tests output.
+# But you can enable it at the command line with:
+#
+#   DEBUG=true bundle exec rake
+#
+# {Representable::Debug}, {Representable::Debug::Binding} and
+# {Representable::Pipeline::Debug} uses {Representable::Logger} for output.
+# So you can turn on and off these classe's output manipulating
+# {Representable::Logger} state.
+
+module Representable::Logger
+
+  # @example
+  #   logger = Representable::Logger
+  #   logger.log("something")
+  #
+  # @param args [String]
+  # @return [nil]
+  def self.log(*args)
+    puts args if Representable::Logger.on?
+  end
+
+  # @example
+  #   class MyClass
+  #     include Representable::Logger
+  #
+  #     def my_method
+  #       log "something"
+  #     end
+  #   end
+  def log(*args)
+    Representable::Logger.log(args)
+  end
+
+  # Check if logging is enabled.
+  def self.on?
+    @logging
+  end
+
+  # Check if logging is disabled.
+  def self.off?
+    !on?
+  end
+
+  # Turns on logger.
+  # Any {#log} call will be outputed to STDOUT.
+  #
+  # @return [Boolean]
+  def self.on!
+    @logging = true
+  end
+
+  # Turns off logger.
+  # Any {#log} call will be discarded.
+  #
+  # @return [Boolean]
+  def self.off!
+    @logging = false
+  end
+
+  on! # default state
+end

--- a/lib/representable/xml/binding.rb
+++ b/lib/representable/xml/binding.rb
@@ -60,7 +60,7 @@ module Representable
       def find_nodes(doc, as)
         selector  = as
         selector  = "#{self[:wrap]}/#{as}" if self[:wrap]
-        nodes     = doc.xpath(selector)
+        doc.xpath(selector) # nodes
       end
 
       def node_for(parent, name)

--- a/representable.gemspec
+++ b/representable.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.platform    = Gem::Platform::RUBY
   spec.authors     = ["Nick Sutterer"]
   spec.email       = ["apotonick@gmail.com"]
-  spec.homepage    = "https://github.com/apotonick/representable/"
+  spec.homepage    = "https://github.com/trailblazer/representable/"
   spec.summary     = %q{Renders and parses JSON/XML/YAML documents from and to Ruby objects. Includes plain properties, collections, nesting, coercion and more.}
   spec.description = spec.summary
 

--- a/representable.gemspec
+++ b/representable.gemspec
@@ -26,9 +26,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "declarative-option", "< 0.2.0"
 
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "test_xml", "0.1.6"
+  spec.add_development_dependency "test_xml"
   spec.add_development_dependency "minitest"
   spec.add_development_dependency "virtus"
   spec.add_development_dependency "multi_json"
   spec.add_development_dependency "ruby-prof" if RUBY_ENGINE == "ruby" # mri
+  spec.add_development_dependency "nokogiri"
+  spec.add_development_dependency "minitest-line"
 end

--- a/test/as_test.rb
+++ b/test/as_test.rb
@@ -7,8 +7,8 @@ class AsTest < MiniTest::Spec
     # :yaml => [Representable::YAML, "---\nsong:\n  name: Alive\n", "---\nsong:\n  name: You've Taken Everything\n"],
   ) do |format, mod, input, output|
 
-    let (:song) { representer.prepare(Song.new("Revolution")) }
-    let (:format) { format }
+    let(:song) { representer.prepare(Song.new("Revolution")) }
+    let(:format) { format }
 
 
     describe "as: with :symbol" do

--- a/test/binding_test.rb
+++ b/test/binding_test.rb
@@ -35,12 +35,12 @@ class BindingTest < MiniTest::Spec
     it { binding.default_for(nil).must_equal "Insider" }
 
     # return nil when value nil and render_nil: true.
-    it { Binding.new(render_nil_definition).default_for(nil).must_equal nil }
+    it { Binding.new(render_nil_definition).default_for(nil).must_be_nil }
 
     # return nil when value nil and render_nil: true, even when :default is set" do
-    it { Binding.new(Representable::Definition.new(:song, :render_nil => true, :default => "The Quest")).default_for(nil).must_equal nil }
+    it { Binding.new(Representable::Definition.new(:song, :render_nil => true, :default => "The Quest")).default_for(nil).must_be_nil }
 
     # return nil if no :default
-    it { Binding.new(Representable::Definition.new(:song)).default_for(nil).must_equal nil }
+    it { Binding.new(Representable::Definition.new(:song)).default_for(nil).must_be_nil }
   end
 end

--- a/test/binding_test.rb
+++ b/test/binding_test.rb
@@ -2,10 +2,10 @@ require 'test_helper'
 
 class BindingTest < MiniTest::Spec
   Binding = Representable::Binding
-  let (:render_nil_definition) { Representable::Definition.new(:song, :render_nil => true) }
+  let(:render_nil_definition) { Representable::Definition.new(:song, :render_nil => true) }
 
   describe "#skipable_empty_value?" do
-    let (:binding) { Binding.new(render_nil_definition) }
+    let(:binding) { Binding.new(render_nil_definition) }
 
     # don't skip when present.
     it { binding.skipable_empty_value?("Disconnect, Disconnect").must_equal false }
@@ -22,8 +22,8 @@ class BindingTest < MiniTest::Spec
 
 
   describe "#default_for" do
-    let (:definition) { Representable::Definition.new(:song, :default => "Insider") }
-    let (:binding) { Binding.new(definition) }
+    let(:definition) { Representable::Definition.new(:song, :default => "Insider") }
+    let(:binding) { Binding.new(definition) }
 
     # return value when value present.
     it { binding.default_for("Black And Blue").must_equal "Black And Blue" }

--- a/test/cached_test.rb
+++ b/test/cached_test.rb
@@ -61,7 +61,7 @@ class CachedTest < MiniTest::Spec
     let (:representer) { AlbumRepresenter.new(album) }
 
     it do
-      album2 = Model::Album.new("Louder And Even More Dangerous", [song2, song])
+      # album2 = Model::Album.new("Louder And Even More Dangerous", [song2, song])
 
       # makes sure options are passed correctly.
       representer.to_hash(user_options: {volume: 9}).must_equal({"name"=>"Live And Dangerous",

--- a/test/cached_test.rb
+++ b/test/cached_test.rb
@@ -81,20 +81,20 @@ class CachedTest < MiniTest::Spec
       data = Profiler.profile { representer.to_hash }
 
       # 3 songs get decorated.
-      data.must_match /3\s*Representable::Function::Decorate#call/m
+      data.must_match(/3\s*Representable::Function::Decorate#call/m)
       # These weird Regexp bellow are a quick workaround to accomodate
       # the different profiler result formats.
       #   - "3   <Class::Representable::Decorator>#prepare" -> At MRI Ruby
       #   - "3  Representable::Decorator.prepare"           -> At JRuby
 
       # 3 nested decorator is instantiated for 3 Songs, though.
-      data.must_match /3\s*(<Class::)?Representable::Decorator\>?[\#.]prepare/m
+      data.must_match(/3\s*(<Class::)?Representable::Decorator\>?[\#.]prepare/m)
       # no Binding is instantiated at runtime.
       data.wont_match "Representable::Binding#initialize"
       # 2 mappers for Album, Song
       # data.must_match "2   Representable::Mapper::Methods#initialize"
       # title, songs, 3x title, composer
-      data.must_match /8\s*Representable::Binding[#\.]render_pipeline/m
+      data.must_match(/8\s*Representable::Binding[#\.]render_pipeline/m)
       data.wont_match "render_functions"
       data.wont_match "Representable::Binding::Factories#render_functions"
     end
@@ -139,12 +139,12 @@ class CachedTest < MiniTest::Spec
       # only 2 nested decorators are instantiated, Song, and Artist.
       # Didn't like the regexp?
       # MRI and JRuby has different output formats. See note above.
-      data.must_match /5\s*(<Class::)?Representable::Decorator>?[#\.]prepare/
+      data.must_match(/5\s*(<Class::)?Representable::Decorator>?[#\.]prepare/)
       # a total of 5 properties in the object graph.
       data.wont_match "Representable::Binding#initialize"
 
       data.wont_match "parse_functions" # no pipeline creation.
-      data.must_match /10\s*Representable::Binding[#\.]parse_pipeline/
+      data.must_match(/10\s*Representable::Binding[#\.]parse_pipeline/)
       # three mappers for Album, Song, composer
       # data.must_match "3   Representable::Mapper::Methods#initialize"
       # # 6 deserializers as the songs collection uses 2.

--- a/test/cached_test.rb
+++ b/test/cached_test.rb
@@ -125,7 +125,7 @@ class CachedTest < MiniTest::Spec
       album.songs[1].title.must_equal "Jailbreak"
       album.songs[1].composer.name.must_equal "Phil Lynott"
       album.songs[2].title.must_equal "Emerald"
-      album.songs[2].composer.must_equal nil
+      album.songs[2].composer.must_be_nil
 
       # TODO: test options.
     end

--- a/test/cached_test.rb
+++ b/test/cached_test.rb
@@ -53,12 +53,12 @@ class CachedTest < MiniTest::Spec
 
 
   describe "serialization" do
-    let (:album_hash) { {"name"=>"Louder And Even More Dangerous", "songs"=>[{"title"=>"Southbound:{:volume=>10}"}, {"title"=>"Jailbreak:{:volume=>10}"}]} }
+    let(:album_hash) { {"name"=>"Louder And Even More Dangerous", "songs"=>[{"title"=>"Southbound:{:volume=>10}"}, {"title"=>"Jailbreak:{:volume=>10}"}]} }
 
-    let (:song) { Model::Song.new("Jailbreak") }
-    let (:song2) { Model::Song.new("Southbound") }
-    let (:album) { Model::Album.new("Live And Dangerous", [song, song2, Model::Song.new("Emerald")]) }
-    let (:representer) { AlbumRepresenter.new(album) }
+    let(:song) { Model::Song.new("Jailbreak") }
+    let(:song2) { Model::Song.new("Southbound") }
+    let(:album) { Model::Album.new("Live And Dangerous", [song, song2, Model::Song.new("Emerald")]) }
+    let(:representer) { AlbumRepresenter.new(album) }
 
     it do
       # album2 = Model::Album.new("Louder And Even More Dangerous", [song2, song])
@@ -102,7 +102,7 @@ class CachedTest < MiniTest::Spec
 
 
   describe "deserialization" do
-    let (:album_hash) {
+    let(:album_hash) {
       {
         "name"=>"Louder And Even More Dangerous",
         "songs"=>[

--- a/test/class_test.rb
+++ b/test/class_test.rb
@@ -54,7 +54,7 @@ class ClassTest < BaseTest
 
 
   describe "lambda receiving fragment and args" do
-    let (:klass) { Class.new do
+    let(:klass) { Class.new do
       class << self
         attr_accessor :args
       end
@@ -75,7 +75,7 @@ class ClassTest < BaseTest
 
 
   describe "collection: lambda receiving fragment and args" do
-    let (:klass) { Class.new do
+    let(:klass) { Class.new do
       class << self
         attr_accessor :args
       end

--- a/test/coercion_test.rb
+++ b/test/coercion_test.rb
@@ -17,7 +17,7 @@ class VirtusCoercionTest < MiniTest::Spec
     end
   end
 
-  let (:album) { OpenStruct.new(:title => "Dire Straits", :length => 41.34,
+  let(:album) { OpenStruct.new(:title => "Dire Straits", :length => 41.34,
     :band  => OpenStruct.new(:founded => "1977"),
     :songs => [OpenStruct.new(:ok => 1), OpenStruct.new(:ok => 0)]) }
 

--- a/test/config_test.rb
+++ b/test/config_test.rb
@@ -7,7 +7,7 @@ class ConfigTest < MiniTest::Spec
 
   describe "wrapping" do
     it "returns false per default" do
-      assert_equal nil, subject.wrap_for("Punk", nil)
+      assert_nil subject.wrap_for("Punk", nil)
     end
 
     # it "infers a printable class name if set to true" do
@@ -23,13 +23,13 @@ class ConfigTest < MiniTest::Spec
 
   describe "#[]" do
     # does return nil for non-existent
-    it { subject[:hello].must_equal nil }
+    it { subject[:hello].must_be_nil }
   end
 
   # describe "#[]" do
   #   before { subject.add(:title, {:me => true}) }
 
-  #   it { subject[:unknown].must_equal     nil }
+  #   it { subject[:unknown].must_be_nil }
   #   it { subject.get(:title)[:me].must_equal  true }
   #   it { subject["title"][:me].must_equal true }
   # end
@@ -59,7 +59,7 @@ class ConfigTest < MiniTest::Spec
     # this is actually tested in context in inherit_test.
     it "overrides former definition" do
       subject.add(:title, {:peer => Module})
-      subject.get(:title)[:me].must_equal nil
+      subject.get(:title)[:me].must_be_nil
       subject.get(:title)[:peer].must_equal Module
     end
 
@@ -84,7 +84,7 @@ class ConfigTest < MiniTest::Spec
       subject.get(:genre).must_be_kind_of Representable::Definition
 
       subject.remove(:genre)
-      subject.get(:genre).must_equal nil
+      subject.get(:genre).must_be_nil
     end
   end
 

--- a/test/decorator_scope_test.rb
+++ b/test/decorator_scope_test.rb
@@ -6,7 +6,7 @@ class DecoratorScopeTest < MiniTest::Spec
     property :title, :getter => lambda { |*| title_from_representer }, :decorator_scope => true
   end
 
-  let (:representer_with_method) {
+  let(:representer_with_method) {
     Module.new do
       include Representable::Hash
       property :title, :decorator_scope => true

--- a/test/decorator_test.rb
+++ b/test/decorator_test.rb
@@ -19,13 +19,13 @@ class DecoratorTest < MiniTest::Spec
     property :value
   end
 
-  let (:song) { Song.new("Mama, I'm Coming Home") }
-  let (:album) { Album.new([song]) }
+  let(:song) { Song.new("Mama, I'm Coming Home") }
+  let(:album) { Album.new([song]) }
 
-  let (:rating) { OpenStruct.new(system: 'MPAA', value: 'R') }
+  let(:rating) { OpenStruct.new(system: 'MPAA', value: 'R') }
 
   describe "inheritance" do
-    let (:inherited_decorator) do
+    let(:inherited_decorator) do
       Class.new(AlbumRepresentation) do
         property :best_song
       end.new(Album.new([song], "Stand Up"))
@@ -34,7 +34,7 @@ class DecoratorTest < MiniTest::Spec
     it { inherited_decorator.to_hash.must_equal({"songs"=>[{"name"=>"Mama, I'm Coming Home"}], "best_song"=>"Stand Up"}) }
   end
 
-  let (:decorator) { AlbumRepresentation.new(album) }
+  let(:decorator) { AlbumRepresentation.new(album) }
 
   let(:rating_decorator) { RatingRepresentation.new(rating) }
 

--- a/test/decorator_test.rb
+++ b/test/decorator_test.rb
@@ -43,7 +43,7 @@ class DecoratorTest < MiniTest::Spec
     album.wont_respond_to :to_hash
     song.wont_respond_to :to_hash # DISCUSS: weak test, how to assert blank slate?
     # no @representable_attrs in decorated objects
-    song.instance_variable_get(:@representable_attrs).must_be_nil
+    song.wont_be(:instance_variable_defined?, :@representable_attrs)
 
     rating_decorator.to_hash.must_equal({"system" => "MPAA", "value" => "R"})
   end
@@ -80,8 +80,8 @@ class DecoratorTest < MiniTest::Spec
       representer.new(album).from_hash({"songs"=>[{"name"=>"Atomic Garden"}]})
 
       # no @representable_attrs in decorated objects
-      song.instance_variable_get(:@representable_attrs).must_be_nil
-      album.instance_variable_get(:@representable_attrs).must_be_nil
+      song.wont_be(:instance_variable_defined?, :@representable_attrs)
+      album.wont_be(:instance_variable_defined?, :@representable_attrs)
     end
   end
 end

--- a/test/decorator_test.rb
+++ b/test/decorator_test.rb
@@ -43,7 +43,7 @@ class DecoratorTest < MiniTest::Spec
     album.wont_respond_to :to_hash
     song.wont_respond_to :to_hash # DISCUSS: weak test, how to assert blank slate?
     # no @representable_attrs in decorated objects
-    song.instance_variable_get(:@representable_attrs).must_equal nil
+    song.instance_variable_get(:@representable_attrs).must_be_nil
 
     rating_decorator.to_hash.must_equal({"system" => "MPAA", "value" => "R"})
   end
@@ -80,8 +80,8 @@ class DecoratorTest < MiniTest::Spec
       representer.new(album).from_hash({"songs"=>[{"name"=>"Atomic Garden"}]})
 
       # no @representable_attrs in decorated objects
-      song.instance_variable_get(:@representable_attrs).must_equal nil
-      album.instance_variable_get(:@representable_attrs).must_equal nil
+      song.instance_variable_get(:@representable_attrs).must_be_nil
+      album.instance_variable_get(:@representable_attrs).must_be_nil
     end
   end
 end

--- a/test/default_test.rb
+++ b/test/default_test.rb
@@ -9,7 +9,7 @@ class DefaultTest < MiniTest::Spec
   end
 
   describe "#from_hash" do
-    let (:song) { Song.new.extend(representer) }
+    let(:song) { Song.new.extend(representer) }
 
     it { song.from_hash({}).must_equal Song.new(nil, "Huber Breeze") }
     # default doesn't apply when empty string.

--- a/test/defaults_options_test.rb
+++ b/test/defaults_options_test.rb
@@ -1,9 +1,9 @@
 require 'test_helper'
 
 class DefaultsOptionsTest < BaseTest
-  let (:format) { :hash }
-  let (:song) { Struct.new(:title, :author_name, :song_volume, :description).new("Revolution", "Some author", 20, nil) }
-  let (:prepared) { representer.prepare song }
+  let(:format) { :hash }
+  let(:song) { Struct.new(:title, :author_name, :song_volume, :description).new("Revolution", "Some author", 20, nil) }
+  let(:prepared) { representer.prepare song }
 
   describe "hash options combined with dynamic options" do
     representer! do

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -6,8 +6,6 @@ class DefinitionTest < MiniTest::Spec
   # TODO: test that we DON'T clone options, that must happen in
   describe "#initialize" do
     it do
-      opts = nil
-
       # new yields the defaultized options HASH.
       definition = Definition.new(:song, :extend => Module) do |options|
         options[:awesome] = true

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -25,14 +25,14 @@ class DefinitionTest < MiniTest::Spec
   end
 
   describe "#[]" do
-    let (:definition) { Definition.new(:song) }
+    let(:definition) { Definition.new(:song) }
     # default is nil.
     it { definition[:bla].must_be_nil }
   end
 
   # merge!
   describe "#merge!" do
-    let (:definition) { Definition.new(:song, :whatever => true) }
+    let(:definition) { Definition.new(:song, :whatever => true) }
 
     # merges new options.
     it { definition.merge!(:something => true)[:something].must_equal true }
@@ -59,7 +59,7 @@ class DefinitionTest < MiniTest::Spec
     end
 
     describe "with :parse_filter" do
-      let (:definition) { Definition.new(:title, :parse_filter => 1) }
+      let(:definition) { Definition.new(:title, :parse_filter => 1) }
 
       # merges :parse_filter and :render_filter.
       it do
@@ -83,7 +83,7 @@ class DefinitionTest < MiniTest::Spec
 
   # delete!
   describe "#delete!" do
-    let (:definition) { Definition.new(:song, serialize: "remove me!") }
+    let(:definition) { Definition.new(:song, serialize: "remove me!") }
 
     before { definition[:serialize].(nil).must_equal "remove me!" }
 

--- a/test/definition_test.rb
+++ b/test/definition_test.rb
@@ -14,7 +14,7 @@ class DefinitionTest < MiniTest::Spec
         options[:parse_filter] << 1
 
         # default variables
-        options[:as].must_equal nil
+        options[:as].must_be_nil
         options[:extend].must_equal Module
       end
       definition.name.must_equal "song"
@@ -29,7 +29,7 @@ class DefinitionTest < MiniTest::Spec
   describe "#[]" do
     let (:definition) { Definition.new(:song) }
     # default is nil.
-    it { definition[:bla].must_equal nil }
+    it { definition[:bla].must_be_nil }
   end
 
   # merge!
@@ -89,7 +89,7 @@ class DefinitionTest < MiniTest::Spec
 
     before { definition[:serialize].(nil).must_equal "remove me!" }
 
-    it { definition.delete!(:serialize)[:serialize].must_equal nil }
+    it { definition.delete!(:serialize)[:serialize].must_be_nil }
   end
 
   # #inspect
@@ -104,7 +104,7 @@ class DefinitionTest < MiniTest::Spec
     end
 
     it "responds to #representer_module" do
-      assert_equal nil, Representable::Definition.new(:song).representer_module
+      assert_nil Representable::Definition.new(:song).representer_module
       assert_equal Hash, Representable::Definition.new(:song, :extend => Hash).representer_module
     end
 
@@ -217,7 +217,7 @@ class DefinitionTest < MiniTest::Spec
   describe ":default => value" do
     it "responds to #default" do
       @def = Representable::Definition.new(:song)
-      assert_equal nil, @def[:default]
+      assert_nil @def[:default]
     end
 
     it "accepts a default value" do

--- a/test/examples/object.rb
+++ b/test/examples/object.rb
@@ -7,8 +7,6 @@ require "pp"
 source = OpenStruct.new(name: "30 Years Live", songs: [
   OpenStruct.new(id: 1, title: "Dear Beloved"), OpenStruct.new(id: 2, title: "Fuck Armageddon")])
 
-pp source
-
 require "representable/object"
 
 class AlbumRepresenter < Representable::Decorator
@@ -27,5 +25,3 @@ Song = Struct.new(:title)
 target = Album.new
 
 AlbumRepresenter.new(target).from_object(source)
-
-pp target

--- a/test/exec_context_test.rb
+++ b/test/exec_context_test.rb
@@ -7,8 +7,8 @@ class ExecContextTest < MiniTest::Spec
     # :yaml => [Representable::YAML, "---\nsong:\n  name: Alive\n", "---\nsong:\n  name: You've Taken Everything\n"],
   ) do |format, mod, input, output|
 
-    let (:song) { representer.prepare(Song.new("Timing")) }
-    let (:format) { format }
+    let(:song) { representer.prepare(Song.new("Timing")) }
+    let(:format) { format }
 
 
     describe "exec_context: nil" do

--- a/test/features_test.rb
+++ b/test/features_test.rb
@@ -24,7 +24,7 @@ class FeaturesTest < MiniTest::Spec
 
   describe "Module" do
     representer! do
-      instance_exec &definition
+      instance_exec(&definition)
     end
 
     it { song.extend(representer).to_hash.must_equal({"title"=>"Is It A Lie", "length"=>"2:31", "details"=>{"title"=>"Is It A Lie"}}) }
@@ -33,7 +33,7 @@ class FeaturesTest < MiniTest::Spec
 
   describe "Decorator" do
     representer!(:decorator => true) do
-      instance_exec &definition
+      instance_exec(&definition)
     end
 
     it { representer.new(song).to_hash.must_equal({"title"=>"Is It A Lie", "length"=>"2:31", "details"=>{"title"=>"Is It A Lie"}}) }

--- a/test/features_test.rb
+++ b/test/features_test.rb
@@ -20,7 +20,7 @@ class FeaturesTest < MiniTest::Spec
     end
   }
 
-  let (:song) { OpenStruct.new(:details => Object.new) }
+  let(:song) { OpenStruct.new(:details => Object.new) }
 
   describe "Module" do
     representer! do

--- a/test/filter_test.rb
+++ b/test/filter_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 class FilterPipelineTest < MiniTest::Spec
-  let (:block1) { lambda { |input, options| "1: #{input}" } }
-  let (:block2) { lambda { |input, options| "2: #{input}" } }
+  let(:block1) { lambda { |input, options| "1: #{input}" } }
+  let(:block2) { lambda { |input, options| "2: #{input}" } }
 
   subject { Representable::Pipeline[block1, block2] }
 

--- a/test/for_collection_test.rb
+++ b/test/for_collection_test.rb
@@ -7,8 +7,8 @@ class ForCollectionTest < MiniTest::Spec
     property :name
   end
 
-  let (:songs) { [Song.new("Days Go By"), Song.new("Can't Take Them All")] }
-  let (:json)  { "[{\"name\":\"Days Go By\"},{\"name\":\"Can't Take Them All\"}]" }
+  let(:songs) { [Song.new("Days Go By"), Song.new("Can't Take Them All")] }
+  let(:json)  { "[{\"name\":\"Days Go By\"},{\"name\":\"Can't Take Them All\"}]" }
 
 
   # Module.for_collection
@@ -20,9 +20,9 @@ class ForCollectionTest < MiniTest::Spec
   ) do |format, mod, output, input|
 
     describe "Module::for_collection [#{format}]" do
-      let (:format) { format }
+      let(:format) { format }
 
-      let (:representer) {
+      let(:representer) {
         Module.new do
           include mod
           property :name#, :as => :title
@@ -40,9 +40,9 @@ class ForCollectionTest < MiniTest::Spec
     end
 
     describe "Module::for_collection without configuration [#{format}]" do
-      let (:format) { format }
+      let(:format) { format }
 
-      let (:representer) {
+      let(:representer) {
         Module.new do
           include mod
           property :name
@@ -55,8 +55,8 @@ class ForCollectionTest < MiniTest::Spec
 
 
     describe "Decorator::for_collection [#{format}]" do
-      let (:format) { format }
-      let (:representer) {
+      let(:format) { format }
+      let(:representer) {
         Class.new(Representable::Decorator) do
           include mod
           property :name

--- a/test/generic_test.rb
+++ b/test/generic_test.rb
@@ -1,10 +1,10 @@
 require 'test_helper'
 
 class GenericTest < MiniTest::Spec # TODO: rename/restructure to CollectionTest.
-  let (:new_album)  { OpenStruct.new.extend(representer) }
-  let (:album)      { OpenStruct.new(:songs => ["Fuck Armageddon"]).extend(representer) }
-  let (:song) { OpenStruct.new(:title => "Resist Stance") }
-  let (:song_representer) { Module.new do include Representable::Hash; property :title end  }
+  let(:new_album)  { OpenStruct.new.extend(representer) }
+  let(:album)      { OpenStruct.new(:songs => ["Fuck Armageddon"]).extend(representer) }
+  let(:song) { OpenStruct.new(:title => "Resist Stance") }
+  let(:song_representer) { Module.new do include Representable::Hash; property :title end  }
 
 
   describe "::collection" do
@@ -32,14 +32,14 @@ class GenericTest < MiniTest::Spec # TODO: rename/restructure to CollectionTest.
     ) do |format, mod, output, input|
 
       describe "nil collections" do
-        let (:format) { format }
+        let(:format) { format }
 
         representer!(:module => mod) do
           collection :songs
           self.representation_wrap = :album if format == :xml
         end
 
-        let (:album) { Album.new.extend(representer) }
+        let(:album) { Album.new.extend(representer) }
 
         it "doesn't render collection in #{format}" do
           render(album).must_equal_document output
@@ -55,14 +55,14 @@ class GenericTest < MiniTest::Spec # TODO: rename/restructure to CollectionTest.
     ) do |format, mod, output, input|
 
       describe "empty collections" do
-        let (:format) { format }
+        let(:format) { format }
 
         representer!(:module => mod) do
           collection :songs
           self.representation_wrap = :album if format == :xml
         end
 
-        let (:album) { OpenStruct.new(:songs => []).extend(representer) }
+        let(:album) { OpenStruct.new(:songs => []).extend(representer) }
 
         it "renders empty collection in #{format}" do
           render(album).must_equal_document output
@@ -79,14 +79,14 @@ class GenericTest < MiniTest::Spec # TODO: rename/restructure to CollectionTest.
     ) do |format, mod, output, input|
 
       describe "render_empty [#{format}]" do
-        let (:format) { format }
+        let(:format) { format }
 
         representer!(:module => mod) do
           collection :songs, :render_empty => false
           self.representation_wrap = :album if format == :xml
         end
 
-        let (:album) { OpenStruct.new(:songs => []).extend(representer) }
+        let(:album) { OpenStruct.new(:songs => []).extend(representer) }
 
         it { render(album).must_equal_document output }
       end

--- a/test/generic_test.rb
+++ b/test/generic_test.rb
@@ -14,7 +14,7 @@ class GenericTest < MiniTest::Spec # TODO: rename/restructure to CollectionTest.
 
     it "doesn't initialize property" do
       new_album.from_hash({})
-      new_album.songs.must_equal nil
+      new_album.songs.must_be_nil
     end
 
     it "leaves properties untouched" do

--- a/test/hash_bindings_test.rb
+++ b/test/hash_bindings_test.rb
@@ -21,7 +21,7 @@ class HashBindingTest < MiniTest::Spec
       it "returns fragment if present" do
         assert_equal "Stick The Flag Up Your Goddamn Ass, You Sonofabitch", @property.read({"song" => "Stick The Flag Up Your Goddamn Ass, You Sonofabitch"}, "song")
         assert_equal "", @property.read({"song" => ""}, "song")
-        assert_equal nil, @property.read({"song" => nil}, "song")
+        assert_nil @property.read({"song" => nil}, "song")
       end
 
       it "returns FRAGMENT_NOT_FOUND if not in document" do

--- a/test/hash_test.rb
+++ b/test/hash_test.rb
@@ -46,7 +46,7 @@ class HashWithScalarPropertyTest < MiniTest::Spec
     # Fixes issue #115
     it "allows nil value in the incoming document and corresponding nil value for the represented" do
       album = Album.new
-      album.title.must_equal nil
+      album.title.must_be_nil
       album.extend(representer).from_hash("title" => nil)
     end
   end
@@ -80,21 +80,21 @@ class HashWithTypedPropertyTest < MiniTest::Spec
     it do
       album = Album.new(Song.new("Pre-medicated Murder"))
       album.extend(representer).from_hash("best_song" => nil)
-      album.best_song.must_equal nil
+      album.best_song.must_be_nil
     end
 
     # nested blank hash creates blank object when not populated.
     it do
       album = Album.new#(Song.new("Pre-medicated Murder"))
       album.extend(representer).from_hash("best_song" => {})
-      album.best_song.name.must_equal nil
+      album.best_song.name.must_be_nil
     end
 
     # Fixes issue #115
     it "allows nil value in the incoming document and corresponding nil value for the represented" do
       album = Album.new
       album.extend(representer).from_hash("best_song" => nil)
-      album.best_song.must_equal nil
+      album.best_song.must_be_nil
     end
   end
 end

--- a/test/hash_test.rb
+++ b/test/hash_test.rb
@@ -9,14 +9,14 @@ class HashPublicMethodsTest < Minitest::Spec
     property :name
   end
 
-  let (:data) { {"id"=>1,"name"=>"Rancid"} }
+  let(:data) { {"id"=>1,"name"=>"Rancid"} }
 
   it { BandRepresenter.new(Band.new).from_hash(data)[:id, :name].must_equal [1, "Rancid"] }
   it { BandRepresenter.new(Band.new).parse(data)[:id, :name].must_equal [1, "Rancid"] }
 
   #---
   # to_hash
-  let (:band) { Band.new(1, "Rancid") }
+  let(:band) { Band.new(1, "Rancid") }
 
   it { BandRepresenter.new(band).to_hash.must_equal data }
   it { BandRepresenter.new(band).render.must_equal data }
@@ -29,7 +29,7 @@ class HashWithScalarPropertyTest < MiniTest::Spec
     property :title
   end
 
-  let (:album) { Album.new("Liar") }
+  let(:album) { Album.new("Liar") }
 
   describe "#to_hash" do
     it "renders plain property" do
@@ -62,7 +62,7 @@ class HashWithTypedPropertyTest < MiniTest::Spec
     end
   end
 
-  let (:album) { Album.new(Song.new("Liar")) }
+  let(:album) { Album.new(Song.new("Liar")) }
 
   describe "#to_hash" do
     it "renders embedded typed property" do
@@ -107,7 +107,7 @@ class HashWithTypedPropertyAndAs < MiniTest::Spec
     end
   end
 
-  let (:album) { OpenStruct.new(:song => Song.new("Liar")).extend(representer) }
+  let(:album) { OpenStruct.new(:song => Song.new("Liar")).extend(representer) }
 
   it { album.to_hash.must_equal("hit" => {"name" => "Liar"}) }
   it { album.from_hash("hit" => {"name" => "Go With Me"}).must_equal OpenStruct.new(:song => Song.new("Go With Me")) }
@@ -119,13 +119,13 @@ end
   #   #     property :name
   #   #   end
 
-  #   #   let (:hash_album) { Module.new do
+  #   #   let(:hash_album) { Module.new do
   #   #     include Representable::XML
   #   #     self.representation_wrap = :album
   #   #     property :song, :extend => hash_song, :class => Song, :as => :hit
   #   #   end }
 
-  #   #   let (:album) { OpenStruct.new(:song => Song.new("Liar")).extend(hash_album) }
+  #   #   let(:album) { OpenStruct.new(:song => Song.new("Liar")).extend(hash_album) }
 
   #   #   it { album.to_xml.must_equal_xml("<album><hit><name>Liar</name></hit></album>") }
   #   #   #it { album.from_hash("hit" => {"name" => "Go With Me"}).must_equal OpenStruct.new(:song => Song.new("Go With Me")) }
@@ -144,7 +144,7 @@ class HashWithTypedCollectionTest < MiniTest::Spec
     end
   end
 
-  let (:album) { Album.new([Song.new("Liar", 1), Song.new("What I Know", 2)]) }
+  let(:album) { Album.new([Song.new("Liar", 1), Song.new("What I Know", 2)]) }
 
   describe "#to_hash" do
     it "renders collection of typed property" do
@@ -164,7 +164,7 @@ class HashWithScalarCollectionTest < MiniTest::Spec
   Album = Struct.new(:songs)
   representer! { collection :songs }
 
-  let (:album) { Album.new(["Jackhammer", "Terrible Man"]) }
+  let(:album) { Album.new(["Jackhammer", "Terrible Man"]) }
 
 
   describe "#to_hash" do

--- a/test/heritage_test.rb
+++ b/test/heritage_test.rb
@@ -3,13 +3,13 @@ require "test_helper"
 class HeritageTest < Minitest::Spec
   module Hello
     def hello
-      puts "Hello!"
+      "Hello!"
     end
   end
 
   module Ciao
     def ciao
-      puts "Ciao!"
+      "Ciao!"
     end
   end
 
@@ -34,15 +34,16 @@ class HeritageTest < Minitest::Spec
     property :id do end # overwrite old :id.
   end
 
-  it do
-    # puts A.heritage.inspect
-    # puts B.heritage.inspect
+  it "B must inherit Hello! feature from A" do
+    B.representable_attrs.get(:id)[:extend].(nil).new(nil).hello.must_equal "Hello!"
+  end
 
-    puts B.representable_attrs.get(:id)[:extend].(nil).new(nil).hello
-    puts B.representable_attrs.get(:id)[:extend].(nil).new(nil).ciao
+  it "B must have Ciao from module (feauture) Ciao" do
+    B.representable_attrs.get(:id)[:extend].(nil).new(nil).ciao.must_equal "Ciao!"
+  end
 
-    # feature Hello must be "inherited" from A and included in new C properties, too.
-    puts C.representable_attrs.get(:id)[:extend].(nil).new(nil).hello
+  it "C must inherit Hello! feature from A" do
+    C.representable_attrs.get(:id)[:extend].(nil).new(nil).hello.must_equal "Hello!"
   end
 
   module M
@@ -56,7 +57,9 @@ class HeritageTest < Minitest::Spec
     feature Ciao
   end
 
-  it do
-    Object.new.extend(N).hello
+  let(:obj_extending_N) { Object.new.extend(N) }
+
+  it "obj should inherit from N, and N from M" do
+    obj_extending_N.hello.must_equal "Hello!"
   end
 end

--- a/test/heritage_test.rb
+++ b/test/heritage_test.rb
@@ -6,12 +6,12 @@ class HeritageTest < Minitest::Spec
       puts "Hello!"
     end
   end
-    module Ciao
+
+  module Ciao
     def ciao
       puts "Ciao!"
     end
   end
-
 
   class A < Representable::Decorator
     include Representable::Hash

--- a/test/if_test.rb
+++ b/test/if_test.rb
@@ -18,14 +18,14 @@ class IfTest < MiniTest::Spec
     band_class.class_eval { property :fame, :if => lambda { |*| false } }
     band = band_class.new
     band.from_hash({"fame"=>"oh yes"})
-    assert_equal nil, band.fame
+    assert_nil band.fame
   end
 
   it "ignores property when :exclude'ed even when condition is true" do
     band_class.class_eval { property :fame, :if => lambda { |*| true } }
     band = band_class.new
     band.from_hash({"fame"=>"oh yes"}, {:exclude => [:fame]})
-    assert_equal nil, band.fame
+    assert_nil band.fame
   end
 
   it "executes block in instance context" do

--- a/test/if_test.rb
+++ b/test/if_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 class IfTest < MiniTest::Spec
-  let (:band_class) { Class.new do
+  let(:band_class) { Class.new do
     include Representable::Hash
     attr_accessor :fame
     self

--- a/test/include_exclude_test.rb
+++ b/test/include_exclude_test.rb
@@ -17,8 +17,8 @@ class IncludeExcludeTest < Minitest::Spec
     end
   end
 
-  let (:song) { Song.new("Listless", Artist.new("7yearsbadluck", 1  )) }
-  let (:decorator) { representer.new(song) }
+  let(:song) { Song.new("Listless", Artist.new("7yearsbadluck", 1  )) }
+  let(:decorator) { representer.new(song) }
 
   describe "#from_hash" do
     it "accepts :exclude option" do

--- a/test/inherit_test.rb
+++ b/test/inherit_test.rb
@@ -10,7 +10,7 @@ class InheritTest < MiniTest::Spec
     property :track, :as => :no
   end
 
-  let (:song) { Song.new(Struct.new(:string).new("Roxanne"), 1) }
+  let(:song) { Song.new(Struct.new(:string).new("Roxanne"), 1) }
 
   describe ":inherit plain property" do
     representer! do
@@ -108,7 +108,7 @@ class InheritTest < MiniTest::Spec
       end
     end
 
-    let (:inheriting) {
+    let(:inheriting) {
       class InheritingDecorator < representer
         include Representable::Debug
         property :hit, :inherit => true do

--- a/test/inherit_test.rb
+++ b/test/inherit_test.rb
@@ -41,7 +41,7 @@ class InheritTest < MiniTest::Spec
     representer! do
       include SongRepresenter
 
-      puts "passing block"
+      # passing block
       property :name, :inherit => true do # inherit as: title
         property :string, :as => :s
         property :length

--- a/test/inline_test.rb
+++ b/test/inline_test.rb
@@ -94,10 +94,12 @@ class InlineTest < MiniTest::Spec
         end
       end
 
-      let (:decorator) { representer.prepare(request) }
+      describe "with :decorator => #{is_decorator}" do
+        let (:decorator) { representer.prepare(request) }
 
-      it { decorator.to_hash.must_equal({"requester"=>"Josephine", "song"=>{"name"=>"Alive"}}) }
-      it { decorator.from_hash({"song"=>{"name"=>"You've Taken Everything"}}).song.name.must_equal "You've Taken Everything"}
+        it { decorator.to_hash.must_equal({"requester"=>"Josephine", "song"=>{"name"=>"Alive"}}) }
+        it { decorator.from_hash({"song"=>{"name"=>"You've Taken Everything"}}).song.name.must_equal "You've Taken Everything"}
+      end
     end
   end
 

--- a/test/inline_test.rb
+++ b/test/inline_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 class InlineTest < MiniTest::Spec
-  let (:song)    { Song.new("Alive") }
-  let (:request) { representer.prepare(OpenStruct.new(:song => song)) }
+  let(:song)    { Song.new("Alive") }
+  let(:request) { representer.prepare(OpenStruct.new(:song => song)) }
 
   {
     :hash => [Representable::Hash, {"song"=>{"name"=>"Alive"}}, {"song"=>{"name"=>"You've Taken Everything"}}],
@@ -19,7 +19,7 @@ class InlineTest < MiniTest::Spec
         end
       end
 
-      let (:format) { format }
+      let(:format) { format }
 
       it { render(request).must_equal_document output }
       it { parse(request, input).song.name.must_equal "You've Taken Everything"}
@@ -36,7 +36,7 @@ class InlineTest < MiniTest::Spec
     collection_options ||= {}
 
     describe "[#{format}] collection with :class" do
-      let (:request) { representer.prepare(OpenStruct.new(:songs => [song])) }
+      let(:request) { representer.prepare(OpenStruct.new(:songs => [song])) }
 
       representer!(:module => mod) do
         collection :songs, collection_options.merge(:class => Song) do
@@ -44,7 +44,7 @@ class InlineTest < MiniTest::Spec
         end
       end
 
-      let (:format) { format } # FIXME: why do we have to define this?
+      let(:format) { format } # FIXME: why do we have to define this?
 
       it { render(request).must_equal_document output }
       it { parse(request, input).songs.first.name.must_equal "You've Taken Everything"}
@@ -83,7 +83,7 @@ class InlineTest < MiniTest::Spec
 
 
   describe "inheriting from outer representer" do
-    let (:request) { Struct.new(:song, :requester).new(song, "Josephine") }
+    let(:request) { Struct.new(:song, :requester).new(song, "Josephine") }
 
     [false, true].each do |is_decorator| # test for module and decorator.
       representer!(:decorator => is_decorator) do
@@ -95,7 +95,7 @@ class InlineTest < MiniTest::Spec
       end
 
       describe "with :decorator => #{is_decorator}" do
-        let (:decorator) { representer.prepare(request) }
+        let(:decorator) { representer.prepare(request) }
 
         it { decorator.to_hash.must_equal({"requester"=>"Josephine", "song"=>{"name"=>"Alive"}}) }
         it { decorator.from_hash({"song"=>{"name"=>"You've Taken Everything"}}).song.name.must_equal "You've Taken Everything"}
@@ -130,7 +130,7 @@ class InlineTest < MiniTest::Spec
   #   end
 
   #   describe ":getter with inline representer" do
-  #     let (:format) { format }
+  #     let(:format) { format }
 
   #     representer!(:module => mod) do
   #       self.representation_wrap = :album
@@ -138,7 +138,7 @@ class InlineTest < MiniTest::Spec
   #       property :artist, :getter => lambda { |args| represented }, :extend => ArtistRepresenter
   #     end
 
-  #     let (:album) { OpenStruct.new(:label => "Epitaph").extend(representer) }
+  #     let(:album) { OpenStruct.new(:label => "Epitaph").extend(representer) }
 
   #     it "renders nested Album-properties in separate section" do
   #       render(album).must_equal_document output
@@ -159,7 +159,7 @@ class InlineTest < MiniTest::Spec
     end
 
     describe ":getter with :decorator" do
-      let (:format) { format }
+      let(:format) { format }
 
       representer!(:module => mod) do
         self.representation_wrap = "album"
@@ -167,7 +167,7 @@ class InlineTest < MiniTest::Spec
         property :artist, :getter => lambda { |args| represented }, :decorator => ArtistDecorator
       end
 
-      let (:album) { OpenStruct.new(:label => "Epitaph").extend(representer) }
+      let(:album) { OpenStruct.new(:label => "Epitaph").extend(representer) }
 
       it "renders nested Album-properties in separate section" do
         render(album).must_equal_document output
@@ -184,7 +184,7 @@ class InlineTest < MiniTest::Spec
   }) do |format, mod, output|
 
     describe "helper method within inline representer [#{format}]" do
-      let (:format) { format }
+      let(:format) { format }
 
       representer!(:module => mod, :decorator => true) do
         self.representation_wrap = :request if format == :xml
@@ -201,7 +201,7 @@ class InlineTest < MiniTest::Spec
         end
       end
 
-      let (:request) { representer.prepare(OpenStruct.new(:song => Song.new("Alive"))) }
+      let(:request) { representer.prepare(OpenStruct.new(:song => Song.new("Alive"))) }
 
       it do
         render(request).must_equal_document output

--- a/test/instance_test.rb
+++ b/test/instance_test.rb
@@ -55,7 +55,7 @@ class InstanceTest < BaseTest
     end
 
     it {
-      album= Struct.new(:songs).new(songs = [
+      album= Struct.new(:songs).new([
       Song.new(1, "The Answer Is Still No"),
       Song.new(2, "")])
 

--- a/test/instance_test.rb
+++ b/test/instance_test.rb
@@ -81,7 +81,7 @@ class InstanceTest < BaseTest
   #     property :song, :instance => lambda { |*| nil }, :extend => song_representer
   #   end
 
-  #   let (:hit) { hit = OpenStruct.new(:song => song).extend(representer) }
+  #   let(:hit) { hit = OpenStruct.new(:song => song).extend(representer) }
 
   #   it "calls #to_hash on song instance, nothing else" do
   #     hit.to_hash.must_equal("song"=>{"title"=>"Resist Stance"})

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -253,9 +253,7 @@ end
         assert_json '{"songName":"22 Acacia Avenue"}', song.to_json
       end
     end
-
-end
-
+  end
 
   class CollectionTest < MiniTest::Spec
     describe "collection :name" do

--- a/test/json_test.rb
+++ b/test/json_test.rb
@@ -11,14 +11,14 @@ class JSONPublicMethodsTest < Minitest::Spec
     property :name
   end
 
-  let (:json) { '{"id":1,"name":"Rancid"}' }
+  let(:json) { '{"id":1,"name":"Rancid"}' }
 
   it { BandRepresenter.new(Band.new).from_json(json)[:id, :name].must_equal [1, "Rancid"] }
   it { BandRepresenter.new(Band.new).parse(json)[:id, :name].must_equal [1, "Rancid"] }
 
   #---
   # to_json
-  let (:band) { Band.new(1, "Rancid") }
+  let(:band) { Band.new(1, "Rancid") }
 
   it { BandRepresenter.new(band).to_json.must_equal json }
   it { BandRepresenter.new(band).render.must_equal json }
@@ -361,7 +361,7 @@ end
 
       describe "parsing" do
         subject { OpenStruct.new.extend(representer) }
-        let (:hsh) { {"7"=>{"name"=>"Contemplation"}} }
+        let(:hsh) { {"7"=>{"name"=>"Contemplation"}} }
 
         it "parses incoming hash" do
           subject.from_hash("songs"=>hsh).songs.must_equal({"7"=>Song.new("Contemplation")})

--- a/test/lonely_test.rb
+++ b/test/lonely_test.rb
@@ -12,7 +12,7 @@ class LonelyRepresenterTest < MiniTest::Spec
   ) do |format, mod, output, input|
 
     describe "[#{format}] lonely collection, render-only" do # TODO: introduce :representable option?
-      let (:format) { format }
+      let(:format) { format }
 
       representer!(module: mod) do
         items do
@@ -20,7 +20,7 @@ class LonelyRepresenterTest < MiniTest::Spec
         end
       end
 
-      let (:album) { [Song.new("Resist Stance"), Song.new("Suffer")].extend(representer) }
+      let(:album) { [Song.new("Resist Stance"), Song.new("Suffer")].extend(representer) }
 
       it "calls #to_hash on song instances, nothing else" do
         render(album).must_equal_document(output)
@@ -36,14 +36,14 @@ class LonelyRepresenterTest < MiniTest::Spec
     property :name
   end
 
-  let (:decorator) { rpr = representer; Class.new(Representable::Decorator) { include Representable::Hash; include rpr } }
+  let(:decorator) { rpr = representer; Class.new(Representable::Decorator) { include Representable::Hash; include rpr } }
 
   describe "JSON::Collection" do
-    let (:songs) { [Song.new("Days Go By"), Song.new("Can't Take Them All")] }
-    let (:json)  { "[{\"name\":\"Days Go By\"},{\"name\":\"Can't Take Them All\"}]" }
+    let(:songs) { [Song.new("Days Go By"), Song.new("Can't Take Them All")] }
+    let(:json)  { "[{\"name\":\"Days Go By\"},{\"name\":\"Can't Take Them All\"}]" }
 
     describe "with contained objects" do
-      let (:representer) {
+      let(:representer) {
         Module.new do
           include Representable::JSON::Collection
           items :class => Song, :extend => SongRepresenter
@@ -80,13 +80,13 @@ class LonelyRepresenterTest < MiniTest::Spec
     end
 
     describe "with contained text" do
-      let (:representer) {
+      let(:representer) {
         Module.new do
           include Representable::JSON::Collection
         end
       }
-      let (:songs) { ["Days Go By", "Can't Take Them All"] }
-      let (:json)  { "[\"Days Go By\",\"Can't Take Them All\"]" }
+      let(:songs) { ["Days Go By", "Can't Take Them All"] }
+      let(:json)  { "[\"Days Go By\",\"Can't Take Them All\"]" }
 
       it "renders contained items #to_json" do
         assert_json json, songs.extend(representer).to_json
@@ -118,14 +118,14 @@ class LonelyRepresenterTest < MiniTest::Spec
 
   describe "JSON::Hash" do  # TODO: move to HashTest.
     describe "with contained objects" do
-      let (:representer) {
+      let(:representer) {
         Module.new do
           include Representable::JSON::Hash
           values :class => Song, :extend => SongRepresenter
         end
       }
-      let (:json)  { "{\"one\":{\"name\":\"Days Go By\"},\"two\":{\"name\":\"Can't Take Them All\"}}" }
-      let (:songs) { {"one" => Song.new("Days Go By"), "two" => Song.new("Can't Take Them All")} }
+      let(:json)  { "{\"one\":{\"name\":\"Days Go By\"},\"two\":{\"name\":\"Can't Take Them All\"}}" }
+      let(:songs) { {"one" => Song.new("Days Go By"), "two" => Song.new("Can't Take Them All")} }
 
       describe "#to_json" do
         it "renders hash" do
@@ -178,13 +178,13 @@ class LonelyRepresenterTest < MiniTest::Spec
 
 
     describe "with scalar" do
-      let (:representer) {
+      let(:representer) {
         Module.new do
           include Representable::JSON::Hash
         end
       }
-      let (:json)  { %{{"one":1,"two":2}} }
-      let (:data) { {one: 2, two: 3} }
+      let(:json)  { %{{"one":1,"two":2}} }
+      let(:data) { {one: 2, two: 3} }
 
       describe "#to_json" do
         it { data.extend(representer).to_json.must_equal %{{"one":2,"two":3}} }

--- a/test/nested_test.rb
+++ b/test/nested_test.rb
@@ -11,7 +11,7 @@ class NestedTest < MiniTest::Spec
 
     [false, true].each do |is_decorator|
       describe "::nested with (inline representer|decorator): #{is_decorator}" do
-        let (:format) { format }
+        let(:format) { format }
 
         representer!(:module => mod, :decorator => is_decorator) do
           nested :label do
@@ -27,8 +27,8 @@ class NestedTest < MiniTest::Spec
           # self.representation_wrap = :album if format == :xml
         end
 
-        let (:album) { Album.new("Epitaph", "Brett Gurewitz", 19) }
-        let (:decorator) { representer.prepare(album) }
+        let(:album) { Album.new("Epitaph", "Brett Gurewitz", 19) }
+        let(:decorator) { representer.prepare(album) }
 
         it "renders nested Album-properties in separate section" do
           render(decorator).must_equal_document output
@@ -49,7 +49,7 @@ class NestedTest < MiniTest::Spec
 
 
     describe "Decorator ::nested with extend:" do
-      let (:format) { format }
+      let(:format) { format }
 
       representer!(:name => :label_rpr) do
       	include mod
@@ -67,7 +67,7 @@ class NestedTest < MiniTest::Spec
         self.representation_wrap = :album if format == :xml
       end
 
-      let (:album) { representer.prepare(Album.new("Epitaph", "Brett Gurewitz", 19)) }
+      let(:album) { representer.prepare(Album.new("Epitaph", "Brett Gurewitz", 19)) }
 
       # TODO: shared example with above.
       it "renders nested Album-properties in separate section" do
@@ -99,7 +99,7 @@ class NestedTest < MiniTest::Spec
       nested :label, :inherit => true, :as => "Label"
     end
 
-    let (:album) { representer.prepare(Album.new("Epitaph", "Brett Gurewitz", 19)) }
+    let(:album) { representer.prepare(Album.new("Epitaph", "Brett Gurewitz", 19)) }
 
     it "renders nested Album-properties in separate section" do
       representer.prepare(album).to_hash.must_equal({"Label"=>{"owner"=>"Brett Gurewitz"}})

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -33,8 +33,8 @@ class ObjectTest < MiniTest::Spec
   it do
     representer.prepare(Song.new("The King Is Dead")).from_object(Song.new)
 
-    target.title.must_equal nil # scalar property gets overridden when nil.
-    target.album.must_equal nil # nested property stays nil.
+    target.title.must_be_nil # scalar property gets overridden when nil.
+    target.album.must_be_nil # nested property stays nil.
   end
 
   # to_object

--- a/test/object_test.rb
+++ b/test/object_test.rb
@@ -18,8 +18,8 @@ class ObjectTest < MiniTest::Spec
     # TODO: collection
   end
 
-  let (:source) { Song.new("The King Is Dead", Album.new("Ruiner", [Song.new("In Vino Veritas II")])) }
-  let (:target) { Song.new }
+  let(:source) { Song.new("The King Is Dead", Album.new("Ruiner", [Song.new("In Vino Veritas II")])) }
+  let(:target) { Song.new }
 
   it do
     representer.prepare(target).from_object(source)

--- a/test/parse_pipeline_test.rb
+++ b/test/parse_pipeline_test.rb
@@ -45,7 +45,6 @@ class ParsePipelineTest < MiniTest::Spec
     end
 
     def instance!(*options)
-      puts "@@@@@ #{options.inspect}"
       Song.new
     end
 
@@ -59,6 +58,5 @@ class ParsePipelineTest < MiniTest::Spec
     album = Album.new
     Representer.new(album).from_hash({"artist"=>{"email"=>"yo"}, "songs"=>[{"title"=>"Affliction"}, {"title"=>"Dream Beater"}]})
     album.songs.must_equal([Song.new("Affliction"), Song.new("Dream Beater")])
-    puts album.inspect
   end
 end

--- a/test/pipeline_test.rb
+++ b/test/pipeline_test.rb
@@ -68,7 +68,7 @@ class PipelineTest < MiniTest::Spec
 
   ######### scalar property
 
-  let (:title) {
+  let(:title) {
     dfn = R::Definition.new(:title)
 
     R::Hash::Binding.new(dfn)
@@ -105,13 +105,13 @@ class PipelineTest < MiniTest::Spec
     property :name
   end
 
-  let (:artist) {
+  let(:artist) {
     dfn = R::Definition.new(:artist, extend: ArtistRepresenter, class: Artist)
 
     R::Hash::Binding.new(dfn)
   }
 
-  let (:song_model) { Song.new("Lime Green", Artist.new("Diesel Boy")) }
+  let(:song_model) { Song.new("Lime Green", Artist.new("Diesel Boy")) }
 
   it "rendering typed property" do
     doc = {}
@@ -146,7 +146,7 @@ class PipelineTest < MiniTest::Spec
 
   ######### collection :ratings
 
-  let (:ratings) {
+  let(:ratings) {
     dfn = R::Definition.new(:ratings, collection: true, skip_render: ->(*) { false })
 
     R::Hash::Binding::Collection.new(dfn)
@@ -167,7 +167,7 @@ class PipelineTest < MiniTest::Spec
   end
 
 ######### collection :songs, extend: SongRepresenter
-  let (:artists) {
+  let(:artists) {
     dfn = R::Definition.new(:artists, collection: true, extend: ArtistRepresenter, class: Artist)
 
     R::Hash::Binding::Collection.new(dfn)
@@ -188,7 +188,7 @@ class PipelineTest < MiniTest::Spec
     doc.must_equal({"artists"=>[{"name"=>"Diesel Boy"}, {"name"=>"Van Halen"}]})
   end
 
-let (:album_model) { Album.new(nil, [Artist.new("Diesel Boy"), Artist.new("Van Halen")]) }
+let(:album_model) { Album.new(nil, [Artist.new("Diesel Boy"), Artist.new("Van Halen")]) }
 
   it "parse typed collection" do
     doc = {"artists"=>[{"name"=>"Diesel Boy"}, {"name"=>"Van Halen"}]}
@@ -212,7 +212,7 @@ let (:album_model) { Album.new(nil, [Artist.new("Diesel Boy"), Artist.new("Van H
 
   # TODO: test with arrays, too, not "only" Pipeline instances.
   describe "#Insert Pipeline[], Function, replace: OldFunction" do
-    let (:pipeline) { P[R::GetValue, R::StopOnSkipable, R::StopOnNil] }
+    let(:pipeline) { P[R::GetValue, R::StopOnSkipable, R::StopOnNil] }
 
     it "returns Pipeline instance when passing in Pipeline instance" do
       P::Insert.(pipeline, R::Default, replace: R::StopOnSkipable).must_be_instance_of(R::Pipeline)

--- a/test/populator_test.rb
+++ b/test/populator_test.rb
@@ -69,8 +69,8 @@ class PopulatorFindOrInstantiateTest < Minitest::Spec
       album.from_hash({"song"=>{"title"=>"Lower"}})
 
       album.song.title.must_equal "Lower"
-      album.song.id.must_equal nil
-      album.song.uid.must_equal nil
+      album.song.id.must_be_nil
+      album.song.uid.must_be_nil
     end
   end
 
@@ -95,8 +95,8 @@ class PopulatorFindOrInstantiateTest < Minitest::Spec
       album.songs[0].uid.must_equal "abcd" # not changed via populator, indicating this is a formerly "persisted" object.
 
       album.songs[1].title.must_equal "Suffer"
-      album.songs[1].id.must_equal nil
-      album.songs[1].uid.must_equal nil
+      album.songs[1].id.must_be_nil
+      album.songs[1].uid.must_be_nil
     end
 
     # TODO: test with existing collection

--- a/test/populator_test.rb
+++ b/test/populator_test.rb
@@ -37,8 +37,11 @@ class PopulatorFindOrInstantiateTest < Minitest::Spec
     end
   end
 
-  Composer = Struct.new(:song)
-  Composer.class_eval do
+  class Composer
+    def initializer(song)
+      @song = song
+    end
+
     def song=(v)
       @song = v
       "Absolute nonsense" # this tests that the populator always returns the correct object.

--- a/test/populator_test.rb
+++ b/test/populator_test.rb
@@ -16,7 +16,7 @@ class PopulatorTest < Minitest::Spec
       end
     end
 
-    let (:album) { Album.new([]) }
+    let(:album) { Album.new([]) }
 
     it do
       album.extend(representer).from_hash("songs"=>[{"id"=>1}, {"id"=>2}], "artist"=>{"name"=>"Waste"})
@@ -58,7 +58,7 @@ class PopulatorFindOrInstantiateTest < Minitest::Spec
       end
     end
 
-    let (:album) { Composer.new.extend(representer).extend(Representable::Debug) }
+    let(:album) { Composer.new.extend(representer).extend(Representable::Debug) }
 
     it "finds by :id and creates new without :id" do
       album.from_hash({"song"=>{"id" => 1, "title"=>"Resist Stance"}})
@@ -85,7 +85,7 @@ class PopulatorFindOrInstantiateTest < Minitest::Spec
       end
     end
 
-    let (:album) { Struct.new(:songs).new([]).extend(representer) }
+    let(:album) { Struct.new(:songs).new([]).extend(representer) }
 
     it "finds by :id and creates new without :id" do
       album.from_hash({"songs"=>[

--- a/test/prepare_test.rb
+++ b/test/prepare_test.rb
@@ -24,7 +24,7 @@ class PrepareTest < BaseTest
         :representable => false # don't call #to_hash.
     end
 
-    let (:hit) { Struct.new(:song).new(song).extend(representer) }
+    let(:hit) { Struct.new(:song).new(song).extend(representer) }
 
     it "calls prepare:, nothing else" do
       # render(hit).must_equal_document(output)
@@ -54,7 +54,7 @@ class PrepareTest < BaseTest
         :representable => false # don't call #to_hash.
     end
 
-    let (:hit) { Struct.new(:song).new.extend(representer) }
+    let(:hit) { Struct.new(:song).new.extend(representer) }
 
     it "calls prepare:, nothing else" do
       # render(hit).must_equal_document(output)

--- a/test/represent_test.rb
+++ b/test/represent_test.rb
@@ -1,8 +1,8 @@
 require 'test_helper'
 
 class RepresentTest < MiniTest::Spec
-  let (:songs) { [song, Song.new("Can't Take Them All")] }
-  let (:song) { Song.new("Days Go By") }
+  let(:songs) { [song, Song.new("Can't Take Them All")] }
+  let(:song) { Song.new("Days Go By") }
 
   for_formats(
     :hash => [Representable::Hash, out=[{"name" => "Days Go By"}, {"name"=>"Can't Take Them All"}], out],
@@ -12,9 +12,9 @@ class RepresentTest < MiniTest::Spec
 
     # Representer.represents detects collection.
     describe "Module#to_/from_#{format}" do
-      let (:format) { format }
+      let(:format) { format }
 
-      let (:representer) {
+      let(:representer) {
         Module.new do
           include mod
           property :name
@@ -29,8 +29,8 @@ class RepresentTest < MiniTest::Spec
 
     # Decorator.represents detects collection.
     describe "Decorator#to_/from_#{format}" do
-      let (:format) { format }
-      let (:representer) {
+      let(:format) { format }
+      let(:representer) {
         Class.new(Representable::Decorator) do
           include mod
           property :name
@@ -53,9 +53,9 @@ class RepresentTest < MiniTest::Spec
 
     # Representer.represents detects singular.
     describe "Module#to_/from_#{format}" do
-      let (:format) { format }
+      let(:format) { format }
 
-      let (:representer) {
+      let(:representer) {
         Module.new do
           include mod
           property :name
@@ -71,8 +71,8 @@ class RepresentTest < MiniTest::Spec
 
     # Decorator.represents detects singular.
     describe "Decorator#to_/from_#{format}" do
-      let (:format) { format }
-      let (:representer) {
+      let(:format) { format }
+      let(:representer) {
         Class.new(Representable::Decorator) do
           include mod
           property :name

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -449,9 +449,9 @@ class RepresentableTest < MiniTest::Spec
     end
 
     describe ":decorator" do
-      let (:extend_rpr) { Module.new { include Representable::Hash; collection :songs, :extend => SongRepresenter } }
-      let (:decorator_rpr) { Module.new { include Representable::Hash; collection :songs, :decorator => SongRepresenter } }
-      let (:songs) { [Song.new("Bloody Mary")] }
+      let(:extend_rpr) { Module.new { include Representable::Hash; collection :songs, :extend => SongRepresenter } }
+      let(:decorator_rpr) { Module.new { include Representable::Hash; collection :songs, :decorator => SongRepresenter } }
+      let(:songs) { [Song.new("Bloody Mary")] }
 
       it "is aliased to :extend" do
         Album.new(songs).extend(extend_rpr).to_hash.must_equal Album.new(songs).extend(decorator_rpr).to_hash
@@ -470,8 +470,8 @@ class RepresentableTest < MiniTest::Spec
     end
 
     describe "::prepare" do
-      let (:song) { Song.new("Still Friends In The End") }
-      let (:album) { Album.new([song]) }
+      let(:song) { Song.new("Still Friends In The End") }
+      let(:album) { Album.new([song]) }
 
       describe "module including Representable" do
         it "uses :extend strategy" do

--- a/test/representable_test.rb
+++ b/test/representable_test.rb
@@ -224,7 +224,7 @@ class RepresentableTest < MiniTest::Spec
       @band = Class.new(Band) { property :name; collection :founders, :writeable => false; attr_accessor :founders }.new
       @band.from_hash("name" => "Iron Maiden", "groupies" => 2, "founders" => ["Steve Harris"])
       assert_equal "Iron Maiden", @band.name
-      assert_equal nil, @band.founders
+      assert_nil @band.founders
     end
 
     it "always returns the represented" do
@@ -261,7 +261,7 @@ class RepresentableTest < MiniTest::Spec
 
         @band = Band.new.extend(repr)
         @band.send(config.first, config.last)
-        assert_equal nil, @band.name, "Failed in #{format}"
+        assert_nil @band.name, "Failed in #{format}"
       end
     end
 

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -116,9 +116,6 @@ class SchemaTest < MiniTest::Spec
     end
   end
 
-  require "pp"
-  pp InheritFromDecorator.representable_attrs.get(:label)[:extend].(nil).representable_attrs
-
   it do
     InheritFromDecorator.new(band).to_hash.must_equal({"genre"=>"Punkrock", "label"=>{"name"=>"Fat Wreck", "city"=>"San Francisco", "employees"=>[{"name"=>"Mike"}], "location"=>{"city"=>"Sanfran"}}})
   end

--- a/test/schema_test.rb
+++ b/test/schema_test.rb
@@ -58,7 +58,7 @@ class SchemaTest < MiniTest::Spec
   end
 
   describe "3-level deep with features" do
-    let (:label) { OpenStruct.new(:name => "Epitaph", :location => OpenStruct.new(:city => "Sanfran", :name => "DON'T SHOW ME!")) }
+    let(:label) { OpenStruct.new(:name => "Epitaph", :location => OpenStruct.new(:city => "Sanfran", :name => "DON'T SHOW ME!")) }
 
     # Module does correctly include features in inlines.
     it { band.extend(Module).to_hash.must_equal({"label"=>{"name"=>"Epitaph", "location"=>{"city"=>"Sanfran"}}, "genre"=>"Punkrock"}) }
@@ -77,8 +77,8 @@ class SchemaTest < MiniTest::Spec
 
   # puts Decorator.representable_attrs[:definitions].inspect
 
-  let (:label) { OpenStruct.new(:name => "Fat Wreck", :city => "San Francisco", :employees => [OpenStruct.new(:name => "Mike")], :location => OpenStruct.new(:city => "Sanfran")) }
-  let (:band) { OpenStruct.new(:genre => "Punkrock", :label => label) }
+  let(:label) { OpenStruct.new(:name => "Fat Wreck", :city => "San Francisco", :employees => [OpenStruct.new(:name => "Mike")], :location => OpenStruct.new(:city => "Sanfran")) }
+  let(:band) { OpenStruct.new(:genre => "Punkrock", :label => label) }
 
 
   # it { FlatlinersDecorator.new( OpenStruct.new(label: OpenStruct.new) ).

--- a/test/skip_test.rb
+++ b/test/skip_test.rb
@@ -39,8 +39,8 @@ class SkipParseTest < MiniTest::Spec
       "airplays" => [{}, {"station" => "JJJ"}, {}],
     }, user_options: { skip?: true })
 
-    song.title.must_equal nil
-    song.band.must_equal nil
+    song.title.must_be_nil
+    song.band.must_be_nil
     song.airplays.must_equal [airplay]
   end
 end

--- a/test/skip_test.rb
+++ b/test/skip_test.rb
@@ -14,7 +14,7 @@ class SkipParseTest < MiniTest::Spec
     end
   end
 
-  let (:song) { OpenStruct.new.extend(representer) }
+  let(:song) { OpenStruct.new.extend(representer) }
 
   # do parse.
   it do
@@ -30,7 +30,7 @@ class SkipParseTest < MiniTest::Spec
   end
 
   # skip parsing.
-  let (:airplay) { OpenStruct.new(station: "JJJ") }
+  let(:airplay) { OpenStruct.new(station: "JJJ") }
 
   it do
     song.from_hash({
@@ -59,8 +59,8 @@ class SkipRenderTest < MiniTest::Spec
     end
   end
 
-  let (:song)      { OpenStruct.new(title: "Black Night", band: OpenStruct.new(name: "Time Again")).extend(representer) }
-  let (:skip_song) { OpenStruct.new(title: "Time Bomb",   band: OpenStruct.new(name: "Rancid")).extend(representer) }
+  let(:song)      { OpenStruct.new(title: "Black Night", band: OpenStruct.new(name: "Time Again")).extend(representer) }
+  let(:skip_song) { OpenStruct.new(title: "Time Bomb",   band: OpenStruct.new(name: "Rancid")).extend(representer) }
 
   # do render.
   it { song.to_hash(user_options: { skip?: true }).must_equal({"title"=>"Black Night", "band"=>{"name"=>"Time Again"}}) }

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -112,7 +112,7 @@ MiniTest::Spec.class_eval do
     def representer_for(modules=[Representable::Hash], &block)
       Module.new do
         extend TestMethods
-        include *modules
+        include(*modules)
         module_exec(&block)
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,6 +95,8 @@ MiniTest::Spec.class_eval do
       mod
     end
 
+    undef :inject_representer if method_defined? :inject_representer
+
     def inject_representer(mod, options)
       return unless options[:inject]
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -138,3 +138,16 @@ Band = Struct.new(:id, :name) do
     attrs.collect { |attr| send(attr) }
   end
 end
+
+# When running tests we print Debug information only if
+# DEBUG is set at command line like:
+#
+# DEBUG=true bundle exec rake
+
+# Set initial debuggin state based on enviroment variable DEBUG
+case ENV['DEBUG']
+when true, 1, '1', 'on', 'true'
+  Representable::Logger.on!
+else
+  Representable::Logger.off!
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -77,7 +77,7 @@ MiniTest::Spec.class_eval do
   end
 
   def self.representer!(options={}, &block)
-    fmt = options # we need that so the 2nd call to ::let (within a ::describe) remembers the right format.
+    fmt = options # we need that so the 2nd call to ::let(within a ::describe) remembers the right format.
 
     name   = options[:name]   || :representer
     format = options[:module] || Representable::Hash
@@ -126,10 +126,10 @@ MiniTest::Spec.class_eval do
 end
 
 class BaseTest < MiniTest::Spec
-  let (:new_album)  { OpenStruct.new.extend(representer) }
-  let (:album)      { OpenStruct.new(:songs => ["Fuck Armageddon"]).extend(representer) }
-  let (:song) { OpenStruct.new(:title => "Resist Stance") }
-  let (:song_representer) { Module.new do include Representable::Hash; property :title end  }
+  let(:new_album)  { OpenStruct.new.extend(representer) }
+  let(:album)      { OpenStruct.new(:songs => ["Fuck Armageddon"]).extend(representer) }
+  let(:song) { OpenStruct.new(:title => "Resist Stance") }
+  let(:song_representer) { Module.new do include Representable::Hash; property :title end  }
 
 end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -82,6 +82,8 @@ MiniTest::Spec.class_eval do
     name   = options[:name]   || :representer
     format = options[:module] || Representable::Hash
 
+    undef_method(name) if method_defined?(name)
+
     let(name) do
       mod = options[:decorator] ? Class.new(Representable::Decorator) : Module.new
 
@@ -103,6 +105,7 @@ MiniTest::Spec.class_eval do
       injected_name = options[:inject]
       injected = send(injected_name) # song_representer
       mod.singleton_class.instance_eval do
+        undef_method(injected_name) if method_defined?(injected_name)
         define_method(injected_name) { injected }
       end
     end

--- a/test/wrap_test.rb
+++ b/test/wrap_test.rb
@@ -8,7 +8,7 @@ class WrapTest < MiniTest::Spec
   class SoftcoreBand < HardcoreBand
   end
 
-  let (:band) { HardcoreBand.new }
+  let(:band) { HardcoreBand.new }
 
   it "returns false per default" do
     assert_nil SoftcoreBand.new.send(:representation_wrap)
@@ -32,8 +32,8 @@ class WrapTest < MiniTest::Spec
   ) do |format, mod, output, input|
 
     describe "[#{format}] dynamic wrap" do
-      let (:band) { representer.prepare(Struct.new(:name, :genre).new("Blink", "Pop")) }
-      let (:format) { format }
+      let(:band) { representer.prepare(Struct.new(:name, :genre).new("Blink", "Pop")) }
+      let(:format) { format }
 
       representer!(:module => mod) do
         self.representation_wrap = lambda { |args| "#{name}#{args[:number]}" }
@@ -65,7 +65,7 @@ class HashDisableWrapTest < MiniTest::Spec
     end
   end
 
-  let (:band) { BandDecorator.prepare(Band.new("Social Distortion")) }
+  let(:band) { BandDecorator.prepare(Band.new("Social Distortion")) }
 
   # direct, local api.
   it do
@@ -90,7 +90,7 @@ class HashDisableWrapTest < MiniTest::Spec
   end
 
 
-  let (:album) { AlbumDecorator.prepare(Album.new(Band.new("Social Distortion", Label.new("Epitaph")))) }
+  let(:album) { AlbumDecorator.prepare(Album.new(Band.new("Social Distortion", Label.new("Epitaph")))) }
 
   # band has wrap turned off per property definition, however, label still has wrap.
   it "renders" do
@@ -120,7 +120,7 @@ class XMLDisableWrapTest < MiniTest::Spec
     # end
   end
 
-  let (:band) { BandDecorator.prepare(Band.new("Social Distortion")) }
+  let(:band) { BandDecorator.prepare(Band.new("Social Distortion")) }
 
   it do
     band.to_xml.must_equal_xml "<bands><name>Social Distortion</name></bands>"
@@ -137,7 +137,7 @@ class XMLDisableWrapTest < MiniTest::Spec
   end
 
 
-  let (:album) { AlbumDecorator.prepare(Album.new(Band.new("Social Distortion", Label.new("Epitaph")))) }
+  let(:album) { AlbumDecorator.prepare(Album.new(Band.new("Social Distortion", Label.new("Epitaph")))) }
 
   # band has wrap turned of per property definition, however, label still has wrap.
   it "rendersxx" do

--- a/test/wrap_test.rb
+++ b/test/wrap_test.rb
@@ -11,7 +11,7 @@ class WrapTest < MiniTest::Spec
   let (:band) { HardcoreBand.new }
 
   it "returns false per default" do
-    assert_equal nil, SoftcoreBand.new.send(:representation_wrap)
+    assert_nil SoftcoreBand.new.send(:representation_wrap)
   end
 
   it "infers a printable class name if set to true" do

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -10,14 +10,14 @@ class XmlPublicMethodsTest < Minitest::Spec
     property :name
   end
 
-  let (:data) { %{<data><id>1</id><name>Rancid</name></data>} }
+  let(:data) { %{<data><id>1</id><name>Rancid</name></data>} }
 
   it { BandRepresenter.new(Band.new).from_xml(data)[:id, :name].must_equal ["1", "Rancid"] }
   it { BandRepresenter.new(Band.new).parse(data)[:id, :name].must_equal ["1", "Rancid"] }
 
   #---
   # to_hash
-  let (:band) { Band.new("1", "Rancid") }
+  let(:band) { Band.new("1", "Rancid") }
 
   it { BandRepresenter.new(band).to_xml.must_equal_xml data }
   it { BandRepresenter.new(band).render.must_equal_xml data }
@@ -381,8 +381,8 @@ class CollectionTest < MiniTest::Spec
 
 
   describe ":wrap" do
-    let (:album) { Album.new.extend(xml_doc) }
-    let (:xml_doc) {
+    let(:album) { Album.new.extend(xml_doc) }
+    let(:xml_doc) {
       Module.new do
         include Representable::XML
         collection :songs, :as => :song, :wrap => :songs
@@ -428,7 +428,7 @@ class CollectionTest < MiniTest::Spec
       self.representation_wrap = :song
     end
 
-    let (:decorator) { rpr = representer; Class.new(Representable::Decorator) { include Representable::XML; include rpr } }
+    let(:decorator) { rpr = representer; Class.new(Representable::Decorator) { include Representable::XML; include rpr } }
 
     describe "XML::Collection" do
       describe "with contained objects" do
@@ -437,8 +437,8 @@ class CollectionTest < MiniTest::Spec
           self.representation_wrap= :songs
         end
 
-        let (:songs) { [Song.new("Days Go By"), Song.new("Can't Take Them All")] }
-        let (:xml_doc)   { "<songs><song><name>Days Go By</name></song><song><name>Can't Take Them All</name></song></songs>" }
+        let(:songs) { [Song.new("Days Go By"), Song.new("Can't Take Them All")] }
+        let(:xml_doc)   { "<songs><song><name>Days Go By</name></song><song><name>Can't Take Them All</name></song></songs>" }
 
         it "renders array" do
           songs.extend(representer).to_xml.must_equal_xml xml_doc
@@ -463,8 +463,8 @@ class CollectionTest < MiniTest::Spec
         self.representation_wrap= :songs
       end
 
-      let (:songs) { {"one" => "Graveyards", "two" => "Can't Take Them All"} }
-      let (:xml_doc)   { "<favs one=\"Graveyards\" two=\"Can't Take Them All\" />" }
+      let(:songs) { {"one" => "Graveyards", "two" => "Can't Take Them All"} }
+      let(:xml_doc)   { "<favs one=\"Graveyards\" two=\"Can't Take Them All\" />" }
 
       describe "#to_xml" do
         it "renders hash" do
@@ -512,7 +512,7 @@ class XmlHashTest < MiniTest::Spec
       hash :songs
     end
 
-    let (:doc) { "<open_struct><first>The Gargoyle</first><second>Bronx</second></open_struct>" }
+    let(:doc) { "<open_struct><first>The Gargoyle</first><second>Bronx</second></open_struct>" }
 
     # to_xml
     it { OpenStruct.new(songs: {"first" => "The Gargoyle", "second" => "Bronx"}).extend(representer).to_xml.must_equal_xml(doc) }
@@ -527,7 +527,7 @@ class XmlHashTest < MiniTest::Spec
       end
     end
 
-    let (:doc) { "<open_struct>
+    let(:doc) { "<open_struct>
   <open_struct>
     <title>The Gargoyle</title>
   </open_struct>

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -145,14 +145,14 @@ class XmlTest < MiniTest::Spec
       module SongRepresenter
         include Representable::XML
         property :name
-        representation_wrap = :song
+        :song # representation_wrap
       end
 
       module AlbumRepresenter
         include Representable::XML
         property :best_song, :class => Song, :extend => SongRepresenter
         collection :songs, :class => Song, :as => :song, :extend => SongRepresenter
-        representation_wrap = :album
+        :album # representation_wrap
       end
 
 

--- a/test/yaml_test.rb
+++ b/test/yaml_test.rb
@@ -29,7 +29,7 @@ class YamlTest < MiniTest::Spec
   def self.yaml_representer(&block)
     Module.new do
       include Representable::YAML
-      instance_exec &block
+      instance_exec(&block)
     end
   end
 

--- a/test/yaml_test.rb
+++ b/test/yaml_test.rb
@@ -9,7 +9,7 @@ class YamlPublicMethodsTest < Minitest::Spec
     property :name
   end
 
-  let (:data) { %{---
+  let(:data) { %{---
 id: 1
 name: Rancid
 } }
@@ -19,7 +19,7 @@ name: Rancid
 
   #---
   # to_yaml
-  let (:band) { Band.new("1", "Rancid") }
+  let(:band) { Band.new("1", "Rancid") }
 
   it { BandRepresenter.new(band).to_yaml.must_equal data }
   it { BandRepresenter.new(band).render.must_equal data }
@@ -39,9 +39,9 @@ class YamlTest < MiniTest::Spec
 
 
   describe "property" do
-    let (:yaml) { yaml_representer do property :best_song end }
+    let(:yaml) { yaml_representer do property :best_song end }
 
-    let (:album) { Album.new.tap do |album|
+    let(:album) { Album.new.tap do |album|
       album.best_song = "Liar"
     end }
 
@@ -75,12 +75,12 @@ best_song: This Song Is Recycled
 
     describe "with :class and :extend" do
       yaml_song = yaml_representer do property :name end
-      let (:yaml_album) { Module.new do
+      let(:yaml_album) { Module.new do
         include Representable::YAML
         property :best_song, :extend => yaml_song, :class => Song
       end }
 
-      let (:album) { Album.new.tap do |album|
+      let(:album) { Album.new.tap do |album|
         album.best_song = Song.new("Liar")
       end }
 
@@ -107,9 +107,9 @@ best_song:
 
 
   describe "collection" do
-    let (:yaml) { yaml_representer do collection :songs end }
+    let(:yaml) { yaml_representer do collection :songs end }
 
-    let (:album) { Album.new.tap do |album|
+    let(:album) { Album.new.tap do |album|
       album.songs = ["Jackhammer", "Terrible Man"]
     end }
 
@@ -149,7 +149,7 @@ songs: [Off Key Melody, Sinking]").must_equal Album.new(["Off Key Melody", "Sink
 
 
     describe "with :class and :extend" do
-      let (:yaml_album) { Module.new do
+      let(:yaml_album) { Module.new do
         include Representable::YAML
         collection :songs, :class => Song do
           property :name
@@ -157,7 +157,7 @@ songs: [Off Key Melody, Sinking]").must_equal Album.new(["Off Key Melody", "Sink
         end
       end }
 
-      let (:album) { Album.new([Song.new("Liar", 1), Song.new("What I Know", 2)]) }
+      let(:album) { Album.new([Song.new("Liar", 1), Song.new("What I Know", 2)]) }
 
 
       describe "#to_yaml" do


### PR DESCRIPTION
Hi @apotonick (cc: @myabc).

Here's the PR I've been working on since last week.
Running Representable tests render a lot of output. 
Some of them were ruby warnings. Although most of them are not dangerous, they are really annoying.

I have separated one type of warning per commit to easy the task of reviewing.

I'd love your feedback and I hope you like and merge it.

Some of the warnings were in others gems, and I have issued PRs on them also:
- [Declarative](https://github.com/apotonick/declarative) - https://github.com/apotonick/declarative/pull/2 - merged  :white_check_mark:
- [diffy](https://github.com/samg/diffy) - https://github.com/samg/diffy/pull/78 - pending 🕘
- [minitest-line](https://github.com/judofyr/minitest-line) - https://github.com/judofyr/minitest-line/pull/13 - already fixed by @grosser  :white_check_mark: