### PR TITLE
Add to_xml encoding option

### DIFF
--- a/lib/representable/xml.rb
+++ b/lib/representable/xml.rb
@@ -44,10 +44,10 @@ module Representable
 
     # Returns a Nokogiri::XML object representing this object.
     def to_node(options={})
-      options[:doc] = Nokogiri::XML::Document.new # DISCUSS: why do we need a fresh Document here?
+      doc = xml_doc(options)
       root_tag = options[:wrap] || representation_wrap(options)
 
-      create_representation_with(Node(options[:doc], root_tag.to_s), options, Binding)
+      create_representation_with(Node(doc, root_tag.to_s), options, Binding)
     end
 
     def to_xml(*args)
@@ -68,6 +68,12 @@ module Representable
 
       node.remove_namespaces! if remove_namespaces?
       node.root
+    end
+
+    def xml_doc(options)
+      doc = options[:doc] || Nokogiri::XML::Document.new
+      doc.encoding = options[:encoding] unless options[:encoding].nil?
+      doc
     end
   end
 end

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -37,6 +37,19 @@ class XmlTest < MiniTest::Spec
     end
   end
 
+  class NestedBand
+    include Representable::XML
+    property :name
+    property :album do
+      property :name
+    end
+    attr_accessor :name, :album
+
+    def initialize(name=nil, album=nil)
+      name and self.name = name
+      album and self.album = OpenStruct.new(name: album)
+    end
+  end
 
   XML = Representable::XML
   Def = Representable::Definition
@@ -99,10 +112,17 @@ class XmlTest < MiniTest::Spec
       end
 
       describe "encoding option" do
+        before do
+          representer = NestedBand.new("Die Ärzte", "Geräusch")
+          @utf_8_xml = representer.to_xml(encoding: "UTF-8")
+          @ascii_xml = representer.to_xml(encoding: "ASCII")
+        end
+
         it "sets the xml encoding" do
-          representer = Band.new("Die Ärzte")
-          assert_includes representer.to_xml(encoding: "UTF-8"), "Ä"
-          assert_includes representer.to_xml(encoding: "ASCII"), "&#196;"
+          assert_includes @utf_8_xml, "Die Ärzte"
+          assert_includes @utf_8_xml, "Geräusch"
+          assert_includes @ascii_xml, "Die &#196;rzte"
+          assert_includes @ascii_xml, "Ger&#228;usch"
         end
       end
     end

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -95,6 +95,14 @@ class XmlTest < MiniTest::Spec
       it "delegates to #to_node and returns string" do
         assert_xml_equal "<band><name>Rise Against</name></band>", Band.new("Rise Against").to_xml
       end
+
+      describe "encoding option" do
+        it "sets the xml encoding" do
+          representer = Band.new("Die Ärzte")
+          assert_includes representer.to_xml(encoding: "UTF-8"), "Ä"
+          assert_includes representer.to_xml(encoding: "ASCII"), "&#196;"
+        end
+      end
     end
 
 

--- a/test/xml_test.rb
+++ b/test/xml_test.rb
@@ -1,3 +1,5 @@
+# encoding: UTF-8
+
 require 'test_helper'
 
 


### PR DESCRIPTION
Adds option to set the encoding of the xml doc created by `to_xml`.

Addresses https://github.com/trailblazer/representable/issues/226