### PR TITLE
Revert 3.1.0 release

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-# 3.1.0
+# 3.1.0.beta1
 * Remove circular require
 * Use Dry-types 1.0.0+ as coercion library
 * Renamed Coercion to VirtusCoercion to support old codebases

--- a/lib/representable/version.rb
+++ b/lib/representable/version.rb
@@ -1,3 +1,3 @@
 module Representable
-  VERSION = "3.1.0"
+  VERSION = "3.1.0.beta1"
 end


### PR DESCRIPTION
This release wasn't tagged on GH or released on rubygems.org. We'll
release ruby-3 support with this release.