### PR TITLE
Add missing `require`

### DIFF
--- a/lib/representable/binding.rb
+++ b/lib/representable/binding.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'uber/delegates'
+
 module Representable
   # The Binding provides methods to read/write the fragment for one property.
   #

--- a/lib/representable/config.rb
+++ b/lib/representable/config.rb
@@ -1,4 +1,8 @@
+require 'declarative/definitions'
+
 module Representable
+  autoload :Option, 'representable/option'
+
   # Stores Definitions from ::property. It preserves the adding order (1.9+).
   # Same-named properties get overridden, just like in a Hash.
   #

--- a/lib/representable/debug.rb
+++ b/lib/representable/debug.rb
@@ -1,4 +1,5 @@
 require 'logger'
+
 module Representable
   module Debug
     module_function def _representable_logger

--- a/lib/representable/declarative.rb
+++ b/lib/representable/declarative.rb
@@ -1,4 +1,9 @@
+require "declarative/schema"
+
 module Representable
+  autoload :Decorator, "representation/decorator"
+  autoload :Definition, "representation/definition"
+
   module Declarative
     def representation_wrap=(name)
       heritage.record(:representation_wrap=, name)

--- a/lib/representable/decorator.rb
+++ b/lib/representable/decorator.rb
@@ -1,4 +1,5 @@
 require "uber/inheritable_attr"
+require "representable"
 
 module Representable
   class Decorator

--- a/lib/representable/definition.rb
+++ b/lib/representable/definition.rb
@@ -1,6 +1,10 @@
-require "representable/populator"
+require 'declarative/definitions'
 
 module Representable
+  autoload :Pipeline, "representable/pipeline"
+  autoload :Populator, "representable/populator"
+  autoload :Option, "representable/option"
+
   # Created at class compile time. Keeps configuration options for one property.
   class Definition < ::Declarative::Definitions::Definition
 

--- a/lib/representable/hash.rb
+++ b/lib/representable/hash.rb
@@ -1,11 +1,14 @@
+require 'representable'
+require 'representable/hash/binding'
+
 module Representable
   # The generic representer. Brings #to_hash and #from_hash to your object.
   # If you plan to write your own representer for a new media type, try to use this module (e.g., check how JSON reuses Hash's internal
   # architecture).
   module Hash
-    autoload :Binding, 'representable/hash/binding'
-    autoload :AllowSymbols, 'representable/hash/allow_symbols'
     autoload :Collection, 'representable/hash/collection'
+    autoload :AllowSymbols, 'representable/hash/allow_symbols'
+
     def self.included(base)
       base.class_eval do
         include Representable # either in Hero or HeroRepresentation.

--- a/lib/representable/hash/binding.rb
+++ b/lib/representable/hash/binding.rb
@@ -1,3 +1,5 @@
+require 'representable/binding'
+
 module Representable
   module Hash
     class Binding < Representable::Binding

--- a/lib/representable/hash/collection.rb
+++ b/lib/representable/hash/collection.rb
@@ -1,3 +1,5 @@
+require 'representable/hash'
+
 module Representable::Hash
   module Collection
     include Representable::Hash

--- a/lib/representable/json.rb
+++ b/lib/representable/json.rb
@@ -1,10 +1,13 @@
 gem "multi_json", '>= 1.14.1'
 require "multi_json"
 
+require "representable"
+
 module Representable
   # Brings #to_json and #from_json to your object.
   module JSON
     autoload :Collection, "representable/json/collection"
+
     extend Hash::ClassMethods
     include Hash
 

--- a/lib/representable/json/collection.rb
+++ b/lib/representable/json/collection.rb
@@ -1,3 +1,6 @@
+require 'representable/json'
+require 'representable/hash/collection'
+
 module Representable::JSON
   module Collection
     include Representable::JSON

--- a/lib/representable/json/hash.rb
+++ b/lib/representable/json/hash.rb
@@ -1,3 +1,6 @@
+require 'representable/json'
+require 'representable/hash_methods'
+
 module Representable::JSON
   # "Lonely Hash" support.
   module Hash

--- a/lib/representable/object.rb
+++ b/lib/representable/object.rb
@@ -1,6 +1,8 @@
+require 'representable'
+require 'representable/object/binding'
+
 module Representable
   module Object
-    autoload :Binding, 'representable/object/binding'
     def self.included(base)
       base.class_eval do
         include Representable

--- a/lib/representable/object/binding.rb
+++ b/lib/representable/object/binding.rb
@@ -1,3 +1,5 @@
+require 'representable/binding'
+
 module Representable
   module Object
     class Binding < Representable::Binding

--- a/lib/representable/xml.rb
+++ b/lib/representable/xml.rb
@@ -1,6 +1,8 @@
 gem 'nokogiri', '> 1.10.8'
 require 'nokogiri'
 
+require 'representable'
+
 module Representable
   module XML
     autoload :Binding, 'representable/xml/binding'

--- a/lib/representable/xml/binding.rb
+++ b/lib/representable/xml/binding.rb
@@ -1,3 +1,5 @@
+require 'representable/binding'
+
 module Representable
   module XML
     module_function def Node(document, name, attributes={})

--- a/lib/representable/xml/hash.rb
+++ b/lib/representable/xml/hash.rb
@@ -1,3 +1,6 @@
+require 'representable/xml'
+require 'representable/hash_methods'
+
 module Representable::XML
   module AttributeHash
     include Representable::XML

--- a/lib/representable/yaml.rb
+++ b/lib/representable/yaml.rb
@@ -1,9 +1,9 @@
 require 'psych'
+require 'representable'
 
 module Representable
   module YAML
     autoload :Binding, 'representable/yaml/binding'
-
     include Hash
 
     def self.included(base)

--- a/lib/representable/yaml/binding.rb
+++ b/lib/representable/yaml/binding.rb
@@ -1,3 +1,5 @@
+require 'representable/hash/binding'
+
 module Representable
   module YAML
     class Binding < Representable::Hash::Binding


### PR DESCRIPTION
**Issue**

`reform` is failing on requiring latest changes from `master`
because of some missing `require`s.

**Test to reproduce**

https://github.com/yogeshjain999/reform/commit/cfb58e3f1ad30f992778bb2d0d23d9fb8ea2d10d

**Test run**

https://github.com/yogeshjain999/reform/actions/runs/732842422

**Fix**

Make requiring files (xml, json, hash etc) explicitly possible. This
includes some reverts from PR #235 and commit 411abe72. Reasons,

- Many files like `representable/json`, `representable/xml` etc are loaded
directly without `require representable` within dependencies.
- Some dependencies (eg: reform) directly refers constants which are marked
to `autoload` (eg: `Representable::Decorator`).