### PR TITLE
Upgrade trb-option to 0.1.1

### DIFF
--- a/representable.gemspec
+++ b/representable.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "uber",               "< 0.2.0"
   spec.add_dependency "declarative",        "< 0.1.0"
-  spec.add_dependency "trailblazer-option", "~> 0.1.0"
+  spec.add_dependency "trailblazer-option", ">= 0.1.1", "< 0.2.0"
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test_xml", ">= 0.1.6"


### PR DESCRIPTION
Supports passing empty `keyword_arguments`