### PR TITLE
Hash value of `null` breaks parsing

### DIFF
--- a/lib/representable/hash/binding.rb
+++ b/lib/representable/hash/binding.rb
@@ -10,6 +10,7 @@ module Representable
       end
 
       def read(hash, as)
+        return FragmentNotFound unless hash
         hash.has_key?(as) ? hash[as] : FragmentNotFound
       end
 

--- a/test/hash_bindings_test.rb
+++ b/test/hash_bindings_test.rb
@@ -29,15 +29,7 @@ class HashBindingTest < MiniTest::Spec
       end
 
       it "will not fail if given an empty hash value and will return FRAGMENT_NOT_FOUND" do
-        not_failed = true
-        result = nil
-        begin
-          result = @property.read(nil, "song")
-        rescue NoMethodError
-          not_failed = false
-        end
-        assert not_failed
-        assert_equal Representable::Binding::FragmentNotFound, result
+        assert_equal Representable::Binding::FragmentNotFound, @property.read(nil, "song")
       end
     end
   end

--- a/test/hash_bindings_test.rb
+++ b/test/hash_bindings_test.rb
@@ -28,6 +28,17 @@ class HashBindingTest < MiniTest::Spec
         assert_equal Representable::Binding::FragmentNotFound, @property.read({}, "song")
       end
 
+      it "will not fail if given an empty hash value and will return FRAGMENT_NOT_FOUND" do
+        not_failed = true
+        result = nil
+        begin
+          result = @property.read(nil, "song")
+        rescue NoMethodError
+          not_failed = false
+        end
+        assert not_failed
+        assert_equal Representable::Binding::FragmentNotFound, result
+      end
     end
   end
 


### PR DESCRIPTION
Hey everybody, I don't now if this would belong into https://github.com/trailblazer/representable/pull/203 

but I had a GraphQL-JSON-collection that I tried to parse with `representable`. 
Because of an error the collection came out as: 

```
{
...,
collection: [
 {
...
},
null,
{
...
}
]
...}
```

This completely broke the parsing flow and error-out with `NoMethodError: undefined method has_key? for nil:NilClass` on https://github.com/trailblazer/representable/blob/df685c81aec07f2466832de6d455c9720a87d202/lib/representable/hash/binding.rb#L12

Expected behaviour would have been to just return nothing. I could even imagine a scenario, where `null`-entries would result in `nil`. 

I resorted to filter the collection with a `skip_parse`-first, but an exception in this case is kinda annoying.